### PR TITLE
CI: Use 2020 resolver for pip to ensure correct resolution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -910,7 +910,7 @@ jobs:
             virtualenv --python=python sdist
             source sdist/bin/activate
             pip install --upgrade "pip>=19.1" numpy
-            pip install dist/fmriprep*.tar.gz
+            pip install --use-feature=2020-resolver dist/fmriprep*.tar.gz
             which fmriprep | grep sdist\\/bin
             INSTALLED_VERSION=$(fmriprep --version)
             INSTALLED_VERSION=${INSTALLED_VERSION%$'\r'}
@@ -927,7 +927,7 @@ jobs:
             twine check dist/fmriprep*.whl
             virtualenv --python=python wheel
             source wheel/bin/activate
-            pip install dist/fmriprep*.whl
+            pip install --use-feature=2020-resolver dist/fmriprep*.whl
             which fmriprep | grep wheel\\/bin
             INSTALLED_VERSION=$(fmriprep --version)
             INSTALLED_VERSION=${INSTALLED_VERSION%$'\r'}


### PR DESCRIPTION
In PyPI checks, we see:

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.
```

This PR adds the suggested flag to ensure we won't get caught short in October.