### PR TITLE
FIX: Clarify phase encoding direction, rather than axis

### DIFF
--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -194,10 +194,12 @@ class FunctionalSummary(SummaryInterface):
                 '(boundary-based registration, BBR) - %d dof' % dof,
                 'FreeSurfer <code>mri_coreg</code> - %d dof' % dof],
         }[self.inputs.registration][self.inputs.fallback]
-        if self.inputs.pe_direction is None:
-            pedir = 'MISSING - Assuming Anterior-Posterior'
-        else:
-            pedir = {'i': 'Left-Right', 'j': 'Anterior-Posterior'}[self.inputs.pe_direction[0]]
+        pedir = {
+            'i-': 'Left-Right',
+            'i': 'Right-Left',
+            'j-': 'Anterior-Posterior',
+            'j': 'Posterior-Anterior'
+        }.get(self.inputs.pe_direction, 'MISSING - Assuming Anterior-Posterior')
 
         if isdefined(self.inputs.confounds_file):
             with open(self.inputs.confounds_file) as cfh:

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -33,6 +33,7 @@ FUNCTIONAL_TEMPLATE = """\
 \t\t<details open>
 \t\t<summary>Summary</summary>
 \t\t<ul class="elem-desc">
+\t\t\t<li>Original orientation: {ornt}</li>
 \t\t\t<li>Repetition time (TR): {tr:.03g}s</li>
 \t\t\t<li>Phase-encoding (PE) direction: {pedir}</li>
 \t\t\t<li>{multiecho}</li>
@@ -235,7 +236,7 @@ class FunctionalSummary(SummaryInterface):
         return FUNCTIONAL_TEMPLATE.format(
             pedir=pedir, stc=stc, sdc=self.inputs.distortion_correction, registration=reg,
             confounds=re.sub(r'[\t ]+', ', ', conflist), tr=self.inputs.tr,
-            dummy_scan_desc=dummy_scan_msg, multiecho=multiecho)
+            dummy_scan_desc=dummy_scan_msg, multiecho=multiecho, ornt=self.inputs.orientation)
 
 
 class AboutSummaryInputSpec(BaseInterfaceInputSpec):

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -173,6 +173,7 @@ class FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
     dummy_scans = traits.Either(traits.Int(), None, desc='number of dummy scans specified by user')
     algo_dummy_scans = traits.Int(desc='number of dummy scans determined by algorithm')
     echo_idx = traits.List([], usedefault=True, desc="BIDS echo identifiers")
+    orientation = traits.Str(mandatory=True, desc='Orientation of the voxel axes')
 
 
 class FunctionalSummary(SummaryInterface):
@@ -194,12 +195,25 @@ class FunctionalSummary(SummaryInterface):
                 '(boundary-based registration, BBR) - %d dof' % dof,
                 'FreeSurfer <code>mri_coreg</code> - %d dof' % dof],
         }[self.inputs.registration][self.inputs.fallback]
-        pedir = {
-            'i-': 'Left-Right',
-            'i': 'Right-Left',
-            'j-': 'Anterior-Posterior',
-            'j': 'Posterior-Anterior'
-        }.get(self.inputs.pe_direction, 'MISSING - Assuming Anterior-Posterior')
+
+        # Verify PhaseEncodingDirection
+        PEdirs = {
+            'RAS': {
+                'i': 'Left-Right',
+                'i-': 'Right-Left',
+                'j-': 'Anterior-Posterior',
+                'j': 'Posterior-Anterior',
+            },
+            'LAS': {
+                'i-': 'Left-Right',
+                'i': 'Right-Left',
+                'j-': 'Anterior-Posterior',
+                'j': 'Posterior-Anterior',
+            },
+        }
+        pedir = PEdirs.get(self.inputs.orientation, {}).get(
+            self.inputs.pe_direction, "MISSING - Assuming Anterior-Posterior"
+        )
 
         if isdefined(self.inputs.confounds_file):
             with open(self.inputs.confounds_file) as cfh:

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -263,13 +263,14 @@ def get_world_pedir(ornt, pe_direction):
     )
     ax_idcs = {"i": 0, "j": 1, "k": 2}
 
-    axcode = ornt[ax_idcs[pe_direction[0]]]
-    inv = pe_direction[1:] == "-"
+    if pe_direction is not None:
+        axcode = ornt[ax_idcs[pe_direction[0]]]
+        inv = pe_direction[1:] == "-"
 
-    for ax in axes:
-        for flip in (ax, ax[::-1]):
-            if flip[not inv].startswith(axcode):
-                return "-".join(flip)
+        for ax in axes:
+            for flip in (ax, ax[::-1]):
+                if flip[not inv].startswith(axcode):
+                    return "-".join(flip)
     LOGGER.warning(
         "Cannot determine world direction of phase encoding. "
         f"Orientation: {ornt}; PE dir: {pe_direction}"

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -200,7 +200,7 @@ class FunctionalSummary(SummaryInterface):
                 'FreeSurfer <code>mri_coreg</code> - %d dof' % dof],
         }[self.inputs.registration][self.inputs.fallback]
 
-        pedir = get_world_pedir(self.inputs.pe_direction, self.inputs.orientation)
+        pedir = get_world_pedir(self.inputs.orientation, self.inputs.pe_direction)
 
         if isdefined(self.inputs.confounds_file):
             with open(self.inputs.confounds_file) as cfh:

--- a/fmriprep/interfaces/tests/test_reports.py
+++ b/fmriprep/interfaces/tests/test_reports.py
@@ -1,0 +1,21 @@
+import pytest
+
+from ..reports import get_world_pedir
+
+
+@pytest.mark.parametrize("orientation,pe_dir,expected", [
+    ('RAS', 'j', 'Posterior-Anterior'),
+    ('RAS', 'j-', 'Anterior-Posterior'),
+    ('RAS', 'i', 'Left-Right'),
+    ('RAS', 'i-', 'Right-Left'),
+    ('RAS', 'k', 'Inferior-Superior'),
+    ('RAS', 'k-', 'Superior-Inferior'),
+    ('LAS', 'j', 'Posterior-Anterior'),
+    ('LAS', 'i-', 'Left-Right'),
+    ('LAS', 'k-', 'Superior-Inferior'),
+    ('LPI', 'j', 'Anterior-Posterior'),
+    ('LPI', 'i-', 'Left-Right'),
+    ('LPI', 'k-', 'Inferior-Superior'),
+])
+def test_get_world_pedir(tmpdir, orientation, pe_dir, expected):
+    assert get_world_pedir(orientation, pe_dir) == expected

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -160,6 +160,8 @@ def init_func_preproc_wf(bold_file):
     # Take first file as reference
     ref_file = pop_file(bold_file)
     metadata = layout.get_metadata(ref_file)
+    # get original image orientation
+    ref_orientation = get_img_orientation(ref_file)
 
     echo_idxs = listify(entities.get("echo", []))
     multiecho = len(echo_idxs) > 2
@@ -269,7 +271,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             registration_init=config.workflow.bold2t1w_init,
             pe_direction=metadata.get("PhaseEncodingDirection"),
             echo_idx=echo_idxs,
-            tr=metadata.get("RepetitionTime")),
+            tr=metadata.get("RepetitionTime"),
+            orientation=ref_orientation),
         name='summary', mem_gb=config.DEFAULT_MEMORY_MIN_GB, run_without_submitting=True)
     summary.inputs.dummy_scans = config.workflow.dummy_scans
 
@@ -962,3 +965,9 @@ def extract_entities(file_list):
     return {
         k: _unique(v) for k, v in entities.items()
     }
+
+
+def get_img_orientation(imgf):
+    """Return the image orientation as a string"""
+    img = nb.load(imgf)
+    return ''.join(nb.aff2axcodes(img.affine))


### PR DESCRIPTION
BOLD runs' `FunctionalSummary` nodes were returning PE-Axis instead of PE-Direction.