### PR TITLE
MAINT: Failing CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       SCRATCH: "/scratch"
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout
@@ -119,7 +119,7 @@ jobs:
   get_data:
     machine:
       # Ubuntu 14.04 with Docker 17.10.0-ce
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /home/circleci/data
     steps:
       - restore_cache:
@@ -235,7 +235,7 @@ jobs:
 
   test_pytest:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout:
@@ -329,7 +329,7 @@ jobs:
 
   ds005:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /tmp/ds005
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
@@ -572,7 +572,7 @@ jobs:
 
   ds054:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /tmp/ds054
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
@@ -744,7 +744,7 @@ jobs:
 
   ds210:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /tmp/ds210
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
@@ -891,7 +891,7 @@ jobs:
 
   deploy_docker_patches:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /tmp/src/fmriprep
     steps:
 
@@ -952,7 +952,7 @@ jobs:
 
   deploy_docker:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     pybids >= 0.11.1
     pyyaml
     requests
+    scikit-image ~= 0.17.2
     sdcflows ~= 1.3.2
     smriprep ~= 0.7.0
     tedana >= 0.0.9a1, < 0.0.10


### PR DESCRIPTION
This updates the base images for our circle tests, and bumps the numpy and scipy versions as the one we're currently using is raising an error.

Given that this is the LTS branch, are we comfortable moving to a different minor of the above packages? 