### PR TITLE
PIN: tedana 0.0.9a1 for LTS branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     scikit-image ~= 0.17.2
     sdcflows ~= 1.3.2
     smriprep ~= 0.7.0
-    tedana >= 0.0.9a1, < 0.0.10
+    tedana == 0.0.9a1
     templateflow >= 0.6
     toml
 test_requires =


### PR DESCRIPTION
tedana 0.0.9 requires scipy 1.3.3+ and scikit-learn 0.22+

Upgrading to 0.0.9+ would break our commitment to avoid non-bug-fix changes to underlying libraries during the LTS window.