### PR TITLE
[ENH] Improve `_get_series_len` performance

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -220,7 +220,7 @@ def init_func_preproc_wf(bold_file):
     run_stc = (
         bool(metadata.get("SliceTiming"))
         and 'slicetiming' not in config.workflow.ignore
-        and (_get_series_len(ref_file) > 4 or "TooShort")
+        and (_get_series_len(ref_file, config.workflow.dummy_scans) > 4 or "TooShort")
     )
 
     # Build workflow
@@ -874,15 +874,13 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     return workflow
 
 
-def _get_series_len(bold_fname):
+def _get_series_len(bold_fname, skip_vols):
     from niworkflows.interfaces.registration import _get_vols_to_discard
     img = nb.load(bold_fname)
     if len(img.shape) < 4:
         return 1
 
-    if isinstance(config.workflow.dummy_scans, int):
-        skip_vols = config.workflow.dummy_scans
-    else:
+    if skip_vols is None:
         skip_vols = _get_vols_to_discard(img)
 
     return img.shape[3] - skip_vols

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -880,7 +880,10 @@ def _get_series_len(bold_fname):
     if len(img.shape) < 4:
         return 1
 
-    skip_vols = _get_vols_to_discard(img)
+    if isinstance(config.workflow.dummy_scans, int):
+        skip_vols = config.workflow.dummy_scans
+    else:
+        skip_vols = _get_vols_to_discard(img)
 
     return img.shape[3] - skip_vols
 


### PR DESCRIPTION
Fixes #2405

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
When `dummy_scans` is provided in the configuration, we do not need to estimate the number of non-steady-state volumes, thus increasing performance of workflow creation.

This effectively halves the time needed for `init_func_preproc_wf` in my test dataset.
<img width="1458" alt="2021-04-28_14-45" src="https://user-images.githubusercontent.com/789054/116406085-9a90a780-a830-11eb-8fdf-256198942b94.png">


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

Not applicable

<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
