### PR TITLE
ENH: Bump Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,8 +404,6 @@ jobs:
                          sed -e 's/.* 3\./3./' -e 's/ .*//')
             pyenv local $PY3
             mkdir -p /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
-            sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
             pip install --upgrade pip setuptools
             pip install --upgrade /tmp/src/fmriprep/wrapper/
       - run:
@@ -413,13 +411,9 @@ jobs:
           no_output_timeout: 2h
           command: |
             mkdir -p /tmp/${DATASET}/work /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/work && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/work
             if [ -f /tmp/.nofasttrack ]; then
                 fmriprep-docker -i nipreps/fmriprep:latest \
-                    -e FMRIPREP_DEV 1 -u $(id -u) \
+                    -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                     --network none \
                     --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                     /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
@@ -444,16 +438,12 @@ jobs:
           name: Run full fMRIPrep on ds005 (LegacyMultiProc plugin)
           no_output_timeout: 2h
           command: |
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/work && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/work
             FASTRACK_ARG="--anat-derivatives /tmp/${DATASET}/smriprep-0.6"
             if [ -f /tmp/.nofasttrack ]; then
                 FASTRACK_ARG=""
             fi
             fmriprep-docker -i nipreps/fmriprep:latest \
-                -e FMRIPREP_DEV 1 -u $(id -u) \
+                -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                 --network none \
                 --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                 /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
@@ -499,7 +489,7 @@ jobs:
                 FASTRACK_ARG=""
             fi
             fmriprep-docker -i nipreps/fmriprep:latest \
-                -e FMRIPREP_DEV 1 -u $(id -u) \
+                -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                 --network none \
                 --config $PWD/nipype.cfg -w /tmp/${DATASET}/work_bids \
                 /tmp/data/${DATASET}/ /tmp/${DATASET}/bids participant \
@@ -529,7 +519,7 @@ jobs:
                 FASTRACK_ARG=""
             fi
             fmriprep-docker -i nipreps/fmriprep:latest \
-                -e FMRIPREP_DEV 1 -u $(id -u) \
+                -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                 --network none \
                 --config $PWD/nipype.cfg -w /tmp/${DATASET}/work_partial \
                 /tmp/data/${DATASET} /tmp/${DATASET}/derivatives_partial participant \
@@ -620,8 +610,6 @@ jobs:
                          sed -e 's/.* 3\./3./' -e 's/ .*//')
             pyenv local $PY3
             mkdir -p /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
-            sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
             pip install --upgrade pip setuptools
             pip install --upgrade /tmp/src/fmriprep/wrapper/
       - run:
@@ -652,13 +640,9 @@ jobs:
           no_output_timeout: 2h
           command: |
             mkdir -p /tmp/${DATASET}/work /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/work && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/work
             if [ -f /tmp/.nofasttrack ]; then
                 fmriprep-docker -i nipreps/fmriprep:latest \
-                    -e FMRIPREP_DEV 1 \
+                    -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                     --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                     /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
                     --fs-no-reconall --sloppy --write-graph \
@@ -680,16 +664,12 @@ jobs:
           name: Run full fMRIPrep on ds054
           no_output_timeout: 2h
           command: |
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/work && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/work
             FASTRACK_ARG="--anat-derivatives /tmp/${DATASET}/smriprep-0.6"
             if [ -f /tmp/.nofasttrack ]; then
                 FASTRACK_ARG=""
             fi
             fmriprep-docker -i nipreps/fmriprep:latest \
-                -e FMRIPREP_DEV 1 \
+                -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                 --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                 /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
                 ${FASTRACK_ARG} \
@@ -718,7 +698,7 @@ jobs:
                 /tmp/${DATASET}/derivatives/fmriprep/sub-100185/log/$UUID/
             set +e
             fmriprep-docker -i nipreps/fmriprep:latest \
-                -e FMRIPREP_DEV 1 \
+                -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                 --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                 /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
                 --fs-no-reconall --sloppy --write-graph \
@@ -791,7 +771,7 @@ jobs:
             export PY3=$(pyenv versions | grep '3\.' |
                          sed -e 's/.* 3\./3./' -e 's/ .*//')
             pyenv local $PY3
-            mkdir -p /tmp/${DATASET}/derivatives && sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives && sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
+            mkdir -p /tmp/${DATASET}/derivatives
             pip install --upgrade pip setuptools
             pip install --upgrade /tmp/src/fmriprep/wrapper/
       - run:
@@ -822,13 +802,9 @@ jobs:
           no_output_timeout: 2h
           command: |
             mkdir -p /tmp/${DATASET}/work /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/derivatives
-            sudo setfacl -d -m group:$(id -gn):rwx /tmp/${DATASET}/work && \
-                sudo setfacl -m group:$(id -gn):rwx /tmp/${DATASET}/work
             if [ -f /tmp/.nofasttrack ]; then
                 fmriprep-docker -i nipreps/fmriprep:latest \
-                    -e FMRIPREP_DEV 1 \
+                    -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                     --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                     /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
                     --fs-no-reconall --sloppy --write-graph \
@@ -855,7 +831,7 @@ jobs:
                 FASTRACK_ARG=""
             fi
             fmriprep-docker -i nipreps/fmriprep:latest \
-                -e FMRIPREP_DEV 1 \
+                -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
                 --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                 /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
                 ${FASTRACK_ARG} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ jobs:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       SCRATCH: "/scratch"
     machine:
-      image: ubuntu-1604:202007-01
+      # https://discuss.circleci.com/t/linux-machine-executor-images-2021-april-q2-update/39928
+      # upgrade Docker version
+      image: ubuntu-2004:202104-01
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout
@@ -118,8 +120,7 @@ jobs:
 
   get_data:
     machine:
-      # Ubuntu 14.04 with Docker 17.10.0-ce
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     working_directory: /home/circleci/data
     steps:
       - restore_cache:
@@ -235,7 +236,7 @@ jobs:
 
   test_pytest:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout:
@@ -329,7 +330,7 @@ jobs:
 
   ds005:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     working_directory: /tmp/ds005
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
@@ -572,7 +573,7 @@ jobs:
 
   ds054:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     working_directory: /tmp/ds054
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
@@ -744,7 +745,7 @@ jobs:
 
   ds210:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     working_directory: /tmp/ds210
     environment:
       - FS_LICENSE: /tmp/fslicense/license.txt
@@ -891,7 +892,7 @@ jobs:
 
   deploy_docker_patches:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     working_directory: /tmp/src/fmriprep
     steps:
 
@@ -952,7 +953,7 @@ jobs:
 
   deploy_docker:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,9 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - data-v8-{{ .Branch }}-{{ .Revision }}
-            - data-v8-{{ .Branch }}
-            - data-v8-
+            - data-v9-{{ .Branch }}-{{ .Revision }}
+            - data-v9-{{ .Branch }}
+            - data-v9-
       - run:
           name: Get test data from ds000005
           command: |
@@ -203,7 +203,7 @@ jobs:
               echo "sMRIPrep derivatives of ds000210 were cached"
             fi
       - save_cache:
-         key: data-v8-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+         key: data-v9-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/data
             - /tmp/ds005/freesurfer
@@ -265,7 +265,7 @@ jobs:
             - /tmp/images
       - restore_cache:
           keys:
-            - data-v8-{{ .Revision }}
+            - data-v9-{{ .Revision }}
       - run:
           name: Docker authentication
           command: |
@@ -366,7 +366,7 @@ jobs:
             - /tmp/images
       - restore_cache:
           keys:
-            - data-v8-{{ .Branch }}-{{ .Revision }}
+            - data-v9-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
             - ds005-anat-v18-{{ .Branch }}-{{ .Revision }}
@@ -605,7 +605,7 @@ jobs:
             - /tmp/images
       - restore_cache:
           keys:
-            - data-v8-{{ .Branch }}-{{ .Revision }}
+            - data-v9-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
             - ds054-anat-v14-{{ .Branch }}-{{ .Revision }}
@@ -777,7 +777,7 @@ jobs:
             - /tmp/images
       - restore_cache:
           keys:
-            - data-v8-{{ .Branch }}-{{ .Revision }}
+            - data-v9-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
             - ds210-anat-v12-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
             - /tmp/images
       - restore_cache:
           keys:
-            - data-v9-{{ .Revision }}
+            - data-v9-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Docker authentication
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ RUN curl -sSL "https://dl.dropbox.com/s/gwf51ykkk5bifyj/ants-Linux-centos6_x86_6
     | tar -xzC $ANTSPATH --strip-components 1
 
 # Installing SVGO and bids-validator
-RUN npm install -g svgo@^2.3 bids-validator@^1.7 \
+RUN npm install -g svgo@^2.3 bids-validator@1.7.2 \
   && rm -rf ~/.npm ~/.empty
 
 # Installing and setting up ICA_AROMA

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,18 +203,18 @@ ENV PATH="/usr/local/miniconda/bin:$PATH" \
     PYTHONNOUSERSITE=1
 
 # Installing precomputed python packages
-RUN conda install -y python=3.8 && \
-    conda install -y pip=20.0 && \
-    conda install -y mkl=2020.2 && \
-    conda install -y mkl-service && \
-    conda install -y numpy=1.20 && \
-    conda install -y scipy=1.6 && \
-    conda install -y scikit-learn=0.24 && \
-    conda install -y matplotlib=3.3 && \
-    conda install -y pandas=1.2 && \
-    conda install -y libxslt=1.1 && \
-    conda install -y traits=6.1.0 && \
-    conda install -y zlib; sync && \
+RUN conda install -y python=3.8 \
+                     pip=21.0 \
+                     mkl=2021.2 \
+                     mkl-service=2.3 \
+                     numpy=1.20 \
+                     scipy=1.6 \
+                     scikit-learn=0.24 \
+                     matplotlib=3.3 \
+                     pandas=1.2 \
+                     libxslt=1.1 \
+                     traits=6.2 \
+                     zstd=1.4; sync && \
     chmod -R a+rX /usr/local/miniconda; sync && \
     chmod +x /usr/local/miniconda/bin/*; sync && \
     conda clean -y --all && sync && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,7 @@ RUN curl -sSL "https://dl.dropbox.com/s/gwf51ykkk5bifyj/ants-Linux-centos6_x86_6
     | tar -xzC $ANTSPATH --strip-components 1
 
 # Installing SVGO and bids-validator
-RUN npm install -g svgo bids-validator@1.5.4 \
+RUN npm install -g svgo@^2.3 bids-validator@^1.7 \
   && rm -rf ~/.npm ~/.empty
 
 # Installing and setting up ICA_AROMA

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
                     pkg-config \
                     graphviz \
                     pandoc \
+                    pandoc-citeproc \
                     git && \
     curl -sSL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ RUN curl -sSL "https://dl.dropbox.com/s/gwf51ykkk5bifyj/ants-Linux-centos6_x86_6
     | tar -xzC $ANTSPATH --strip-components 1
 
 # Installing SVGO and bids-validator
-RUN npm install -g svgo@^2.3 bids-validator@1.7.2 \
+RUN npm install -g svgo@^2.3 bids-validator@1.5.7 \
   && rm -rf ~/.npm ~/.empty
 
 # Installing and setting up ICA_AROMA

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -148,10 +148,10 @@ def validate_input_dir(exec_env, bids_dir, participant_label):
         if ignored_subs:
             for sub in ignored_subs:
                 validator_config_dict["ignoredFiles"].append("/sub-%s/**" % sub)
-    with tempfile.NamedTemporaryFile('w+') as temp:
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.json') as temp:
         temp.write(json.dumps(validator_config_dict))
         temp.flush()
         try:
-            subprocess.check_call(['bids-validator', bids_dir, '-c', temp.name])
+            subprocess.check_call(['bids-validator', str(bids_dir), '-c', temp.name])
         except FileNotFoundError:
             print("bids-validator does not appear to be installed", file=sys.stderr)

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ docs =
     %(doc)s
 duecredit = duecredit
 resmon =
-sentry = sentry-sdk >=0.6.9, <0.20
+sentry = sentry-sdk >=0.6.9
 tests =
     coverage
     codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ docs =
     %(doc)s
 duecredit = duecredit
 resmon =
-sentry = sentry-sdk >=0.6.9
+sentry = sentry-sdk >=0.6.9, <0.20
 tests =
     coverage
     codecov

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -29,7 +29,7 @@ __bugreports__ = 'https://github.com/nipreps/fmriprep/issues'
 MISSING = """
 Image '{}' is missing
 Would you like to download? [Y/n] """
-PKG_PATH = '/usr/local/miniconda/lib/python3.7/site-packages'
+PKG_PATH = '/usr/local/miniconda/lib/python3.8/site-packages'
 TF_TEMPLATES = (
     'MNI152Lin',
     'MNI152NLin2009cAsym',

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -158,8 +158,14 @@ def merge_help(wrapper_help, target_help):
     t_usage, t_details = t_help.split('\n\n', 1)
     t_groups = t_details.split('\n\n')
 
+    print("DBG Usage:")
+    print(w_usage)
+    print(t_usage)
     w_posargs = w_usage.split('\n')[-1].lstrip()
     t_posargs = _get_posargs(t_usage)
+    print("DBG Args:")
+    print(w_posargs)
+    print(t_posargs)
 
     w_options = opt_re.findall(w_usage)
     w_flags = sum(map(flag_re.findall, w_options), [])

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -137,10 +137,20 @@ def check_memory(image):
 
 def merge_help(wrapper_help, target_help):
     def _get_posargs(usage):
+        """
+        Extract positional arguments from usage string.
+
+        This function can be used by both native fmriprep (`fmriprep -h`)
+        and the docker wrapper (`fmriprep-docker -h`).
+        """
         posargs = []
-        for t_arg in t_usage.split('\n')[-3:]:
-            line = t_arg.lstrip()
+        for targ in usage.split('\n')[-3:]:
+            line = targ.lstrip()
+            if line.startswith('usage'):
+                continue
             if line[0].isalnum() or line[0] == "{":
+                posargs.append(line)
+            elif line[0] == '[' and (line[1].isalnum() or line[1] == "{"):
                 posargs.append(line)
         return " ".join(posargs)
 
@@ -158,14 +168,8 @@ def merge_help(wrapper_help, target_help):
     t_usage, t_details = t_help.split('\n\n', 1)
     t_groups = t_details.split('\n\n')
 
-    print("DBG Usage:")
-    print(w_usage)
-    print(t_usage)
-    w_posargs = w_usage.split('\n')[-1].lstrip()
+    w_posargs = _get_posargs(w_usage)
     t_posargs = _get_posargs(t_usage)
-    print("DBG Args:")
-    print(w_posargs)
-    print(t_posargs)
 
     w_options = opt_re.findall(w_usage)
     w_flags = sum(map(flag_re.findall, w_options), [])

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -136,6 +136,14 @@ def check_memory(image):
 
 
 def merge_help(wrapper_help, target_help):
+    def _get_posargs(usage):
+        posargs = []
+        for t_arg in t_usage.split('\n')[-3:]:
+            line = t_arg.lstrip()
+            if line[0].isalnum() or line[0] == "{":
+                posargs.append(line)
+        return " ".join(posargs)
+
     # Matches all flags with up to one nested square bracket
     opt_re = re.compile(r'(\[--?[\w-]+(?:[^\[\]]+(?:\[[^\[\]]+\])?)?\])')
     # Matches flag name only
@@ -151,7 +159,7 @@ def merge_help(wrapper_help, target_help):
     t_groups = t_details.split('\n\n')
 
     w_posargs = w_usage.split('\n')[-1].lstrip()
-    t_posargs = t_usage.split('\n')[-1].lstrip()
+    t_posargs = _get_posargs(t_usage)
 
     w_options = opt_re.findall(w_usage)
     w_flags = sum(map(flag_re.findall, w_options), [])

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -417,7 +417,11 @@ def main():
                'DOCKER_VERSION_8395080871=%s' % docker_version]
 
     if not opts.no_tty:
-        command.append('-it')
+        if opts.help:
+            # TTY can corrupt stdout
+            command.append('-i')
+        else:
+            command.append('-it')
 
     # Patch working repositories into installed package directories
     if opts.patch:


### PR DESCRIPTION
This PR bumps up the Docker image base to Ubuntu Focal LTS (20.04).

As a result, a number of packages were updated, including:
- AFNI
- FSL
- Connectome Workbench
- Graphviz
- Pandoc

Furthermore, Python was bumped to 3.8.x, and many of its packages were "modernized" accordingly.

This builds the foundation for #2392 , as it depends on updated scipy. Also closes #2382