### PR TITLE
ENH: Relax requirement for PyBIDS databases to exist

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -165,9 +165,9 @@ def _build_parser():
     g_bids.add_argument(
         "--bids-database-dir",
         metavar="PATH",
-        type=PathExists,
-        help="Path to an existing PyBIDS database folder, for faster indexing "
-             "(especially useful for large datasets)."
+        type=Path,
+        help="Path to a PyBIDS database folder, for faster indexing (especially "
+             "useful for large datasets). Will be created if not present."
     )
 
     g_perfm = parser.add_argument_group("Options to handle performance")

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -439,7 +439,7 @@ class execution(_Config):
             if cls.bids_database_dir:
                 _db_path = cls.bids_database_dir
                 if not _db_path.exists():
-                    logging.getLogger("cli").warn(
+                    logging.getLogger("cli").warning(
                         f"Creating PyBIDS database directory: {_db_path}"
                     )
             else:

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -436,9 +436,15 @@ class execution(_Config):
             import re
             from bids.layout import BIDSLayout
 
-            _db_path = cls.bids_database_dir or (
-                cls.work_dir / cls.run_uuid / "bids_db"
-            )
+            if cls.bids_database_dir:
+                _db_path = cls.bids_database_dir
+                if not _db_path.exists():
+                    logging.getLogger("cli").warn(
+                        f"Creating PyBIDS database directory: {_db_path}"
+                    )
+            else:
+                _db_path = cls.work_dir / cls.run_uuid / "bids_db"
+
             _db_path.mkdir(exist_ok=True, parents=True)
             cls._layout = BIDSLayout(
                 str(cls.bids_dir),


### PR DESCRIPTION
## Changes proposed in this pull request

It can be useful to store the BIDS database separately from the working directory. For example, if you want to preserve the working directory on an HPC run, it will need to be put on (or synced to) a network store. There is no advantage to doing that with an SQLite database as well, so we should permit the location to be specified without pre-generating.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
