### PR TITLE
MAINT: Some dependencies cannot be left unpinned

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,9 @@ url = https://github.com/poldracklab/fmriprep
 python_requires = >=3.7
 install_requires =
     indexed_gzip >= 0.8.8
+    networkx ~= 2.5.0
     nibabel >= 3.0
+    nilearn ~= 0.7.0
     nipype >= 1.4
     nitime
     nitransforms >= 20.0.0rc3,<20.2
@@ -33,9 +35,10 @@ install_requires =
     psutil >= 5.4
     pybids ~= 0.10.2
     pyyaml
+    scikit-image ~= 0.17.0
     sdcflows ~= 1.3.1
     smriprep ~= 0.6.1
-    tedana >= 0.0.9a1, < 0.0.10
+    tedana == 0.0.9a1
     templateflow >=0.4.2, < 0.6.3
     toml
 test_requires =
@@ -58,6 +61,7 @@ doc =
     sphinx-argparse
     sphinx_rtd_theme
     sphinxcontrib-napoleon
+    docutils < 0.17
 docs =
     %(doc)s
 duecredit = duecredit


### PR DESCRIPTION
This PR limits the latest acceptable version of networkx, nilearn and tedana, as they have started to show errors when building the docker image.