### PR TITLE
MNT: Remove /root/.npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ ENV PATH=$ANTSPATH:$PATH
 # Installing SVGO and bids-validator
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install -g svgo bids-validator@1.4.0 &&
+RUN npm install -g svgo bids-validator@1.4.0 && \
     rm -rf /root/.npm
 
 # Installing and setting up ICA_AROMA

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,13 +99,12 @@ RUN mkdir -p $ANTSPATH && \
     | tar -xzC $ANTSPATH --strip-components 1
 ENV PATH=$ANTSPATH:$PATH
 
-# Installing SVGO
+# Installing SVGO and bids-validator
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install -g svgo
-
-# Installing bids-validator
-RUN npm install -g bids-validator@1.4.0
+RUN npm install -g svgo &&
+    npm install -g bids-validator@1.4.0 &&
+    rm -rf /root/.npm
 
 # Installing and setting up ICA_AROMA
 RUN mkdir -p /opt/ICA-AROMA && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,7 @@ ENV PATH=$ANTSPATH:$PATH
 # Installing SVGO and bids-validator
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install -g svgo &&
-    npm install -g bids-validator@1.4.0 &&
+RUN npm install -g svgo bids-validator@1.4.0 &&
     rm -rf /root/.npm
 
 # Installing and setting up ICA_AROMA


### PR DESCRIPTION
Closes #2462.

Combined svgo and bids-validator installation to keep the layer smaller.

Currently, there's a 77MB /root/.npm directory.

```
$ fmriprep-docker --shell            
RUNNING: docker run --rm -e DOCKER_VERSION_8395080871=20.10.7 -it -v /home/chris/Projects/nipreps/fmriprep:/data:ro -v /home/chris/Projects/nipreps/fmriprep:/out --entrypoint=bash nipreps/fmriprep:20.2.2
root@afd4469af151:/tmp# du -sh /root/.npm
77M	/root/.npm
```