### PR TITLE
ENH: Ease CI packaging tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1126,9 +1126,9 @@ workflows:
       - test_deploy_pypi:
           filters:
             branches:
-              ignore:
-                - /docs\/.*/
-                - /docker\/.*/
+              only:
+                - /rel\/.*/
+                - /maint\/.*/
             tags:
               only: /.*/
 


### PR DESCRIPTION
Reduces packaging tests to just
- tags
- release branches
- maintenance branches

This will allow us to stay pinned to the developmental branches
of our nipreps dependencies during active development.