### PR TITLE
ENH: Allow users to download templateflow templates to directory

### DIFF
--- a/scripts/fetch_templates.py
+++ b/scripts/fetch_templates.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
+"""
+Standalone script to facilitate caching of required TemplateFlow templates.
 
-"Pre-emptive caching of commonly used TemplateFlow templates"
-import templateflow.api as tf
+To download and view how to use this script, run the following commands inside a terminal:
+1. wget https://raw.githubusercontent.com/nipreps/fmriprep/master/scripts/fetch_templates.py
+2. python fetch_templates.py -h
+"""
+
+import argparse
+import os
 
 
 def fetch_MNI2009():
@@ -16,12 +23,12 @@ def fetch_MNI2009():
     tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
     tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-01_label-brain_probseg.nii.gz
     """
-    template = 'MNI152NLin2009cAsym'
+    template = "MNI152NLin2009cAsym"
 
-    tf.get(template, resolution=(1, 2), desc=None, suffix='T1w')
-    tf.get(template, resolution=(1, 2), desc='brain', suffix='mask')
-    tf.get(template, resolution=1, atlas=None, desc='carpet', suffix='dseg')
-    tf.get(template, resolution=2, desc='fMRIPrep', suffix='boldref')
+    tf.get(template, resolution=(1, 2), desc=None, suffix="T1w")
+    tf.get(template, resolution=(1, 2), desc="brain", suffix="mask")
+    tf.get(template, resolution=1, atlas=None, desc="carpet", suffix="dseg")
+    tf.get(template, resolution=2, desc="fMRIPrep", suffix="boldref")
     tf.get(template, resolution=1, label="brain", suffix="probseg")
 
 
@@ -35,12 +42,12 @@ def fetch_MNI6():
     tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_res-02_desc-brain_mask.nii.gz
     tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_res-02_atlas-HCP_dseg.nii.gz
     """
-    template = 'MNI152NLin6Asym'
+    template = "MNI152NLin6Asym"
 
-    tf.get(template, resolution=(1, 2), desc=None, suffix='T1w')
-    tf.get(template, resolution=(1, 2), desc='brain', suffix='mask')
+    tf.get(template, resolution=(1, 2), desc=None, suffix="T1w")
+    tf.get(template, resolution=(1, 2), desc="brain", suffix="mask")
     # CIFTI
-    tf.get(template, resolution=2, atlas='HCP', suffix='dseg')
+    tf.get(template, resolution=2, atlas="HCP", suffix="dseg")
 
 
 def fetch_OASIS():
@@ -56,12 +63,12 @@ def fetch_OASIS():
     """
     template = "OASIS30ANTs"
 
-    tf.get(template, resolution=1, desc=None, label=None, suffix='T1w')
-    tf.get(template, resolution=1, label='WM', suffix='probseg')
-    tf.get(template, resolution=1, label='BS', suffix='probseg')
-    tf.get(template, resolution=1, label='brain', suffix='probseg')
-    tf.get(template, resolution=1, label='brain', suffix='mask')
-    tf.get(template, resolution=1, desc='BrainCerebellumExtraction', suffix='mask')
+    tf.get(template, resolution=1, desc=None, label=None, suffix="T1w")
+    tf.get(template, resolution=1, label="WM", suffix="probseg")
+    tf.get(template, resolution=1, label="BS", suffix="probseg")
+    tf.get(template, resolution=1, label="brain", suffix="probseg")
+    tf.get(template, resolution=1, label="brain", suffix="mask")
+    tf.get(template, resolution=1, desc="BrainCerebellumExtraction", suffix="mask")
 
 
 def fetch_fsaverage():
@@ -73,10 +80,10 @@ def fetch_fsaverage():
     tpl-fsaverage/tpl-fsaverage_hemi-L_den-164k_desc-vaavg_midthickness.shape.gii
     tpl-fsaverage/tpl-fsaverage_hemi-R_den-164k_desc-vaavg_midthickness.shape.gii
     """
-    template = 'fsaverage'
+    template = "fsaverage"
 
-    tf.get(template, density='164k', desc='std', suffix='sphere')
-    tf.get(template, density='164k', desc='vaavg', suffix='midthickness')
+    tf.get(template, density="164k", desc="std", suffix="sphere")
+    tf.get(template, density="164k", desc="vaavg", suffix="midthickness")
 
 
 def fetch_fsLR():
@@ -92,10 +99,10 @@ def fetch_fsLR():
     tpl-fsLR/tpl-fsLR_space-fsaverage_hemi-L_den-32k_sphere.surf.gii
     tpl-fsLR/tpl-fsLR_space-fsaverage_hemi-R_den-32k_sphere.surf.gii
     """
-    tf.get('fsLR', density='32k')
+    tf.get("fsLR", density="32k")
 
 
-def main():
+def fetch_all():
     fetch_MNI2009()
     fetch_MNI6()
     fetch_OASIS()
@@ -104,4 +111,21 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description="Helper script for pre-caching required templates to run fMRIPrep",
+    )
+    parser.add_argument(
+        "--tf-dir",
+        type=os.path.abspath,
+        help="Directory to save templates in. If not provided, templates will be saved to"
+        " `${HOME}/.cache/templateflow`.",
+    )
+    opts = parser.parse_args()
+
+    # set envvar (if necessary) prior to templateflow import
+    if opts.tf_dir is not None:
+        os.environ["TEMPLATEFLOW_HOME"] = opts.tf_dir
+
+    import templateflow.api as tf
+
+    fetch_all()


### PR DESCRIPTION
Related to #2480 

Facilitate no network runs by providing users a script to cache templateflow templates to a directory.