### PR TITLE
MAINT: Codename convention proposal - female neuroscientists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
-21.0.0 (TBD)
-============
-First major release in the 21.0.x series.
+21.0.0 *Kreek* (TBD)
+====================
+First major release in the 21.0.x series, codename *Kreek* (after
+`Mary Jeanne Kreek (1937-2021) <https://en.wikipedia.org/wiki/Mary_Jeanne_Kreek>`__,
+neurobiologist specializing in the study and treatment of addiction).
 Upstreams bugfix #2444 (feed *NiTransforms* with LTAs of type RAS2RAS)
 
 .. admonition:: New license - Apache 2.0
@@ -33,6 +35,7 @@ A full list of changes can be found below.
 * DOC: Point documentation at *SDCFlows* and remove SDC section (#2470)
 * DOC: Adds ``--mem`` metavar (#2378)
 * DOC: Skull stripping is forced by default (#2345)
+* MAINT: Codename convention proposal - female neuroscientists (#2488)
 * MAINT: Relicense +20.3.x - BSD-3-Clause -> Apache License 2.0 (#2325)
 * MAINT: Add missing OASIS30 WM/BS probsegs (#2471)
 * MAINT: Update BIDS validator to 1.8.0 (#2443)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,30 @@
 .. include:: links.rst
 
-----------
+-----------------------------------
+*fMRIPrep*'s versioning and changes
+-----------------------------------
+*fMRIPrep* follows the `NiPreps conventions <https://www.nipreps.org/devs/releases/>`__
+for the versioning scheme.
+In short, the basic release form is ``YY.MINOR.PATCH``, so the first release of
+2020 was 20.0.0.
+The most relevant implication to the user is that compatibility of intermediate and
+final results is guaranteed through a given series (in other words, ``YY.MINOR``).
+For instance, version 20.1.4 must be compatible with processing done with 20.1.0.
+
+**Long-term support (LTS) releases**.
+Some releases marked as LTS are special and have a `longer support window
+<https://www.nipreps.org/devs/releases/#long-term-support-series>`__.
+
+**Release codenames**.
+Release series (``YY.MINOR``) share a common *codename*.
+The codename will be one name drawn from `Wikipedia's list of women neuroscientists
+<https://en.wikipedia.org/wiki/List_of_women_neuroscientists>`__.
+This convention was initiated with the 21.0.x «*Kreek*» series, which are named after
+`Mary Jeanne Kreek (1937-2021) <https://en.wikipedia.org/wiki/Mary_Jeanne_Kreek>`__.
+Before this convention was set with 21.0 *Kreek*, only
+`fMRIPrep 1.0 <https://github.com/nipreps/fmriprep/releases/tag/1.0.0>`__ —
+the first official release — had a codename (*BOLD raccoon*).
+
 What's new
 ----------
 


### PR DESCRIPTION
This PR proposes that each fMRIPrep's new series (YY.MINOR.x) receives the name of a female neuroscientist for codename.

To get this convention started, I propose 21.0.x will carry the codename of *Kreek*, after [Mary Jeanne Kreek](https://en.wikipedia.org/wiki/Mary_Jeanne_Kreek), who passed away last March.

Although codenames do not have any effect on functionality, I hope this initiative is received warmly by @nipreps/fmriprep-contributors and I will be pestering you all for some time to make sure there are no objections. Please express your opinions in this PR before it gets merged.

I hope we have a clearer path to adopt these and other changes to the tool when the governance document is pushed forward.