### PR TITLE
ENH: Use ``BIDSLayoutIndexer`` and do not index unnecessary modalities

### DIFF
--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -434,6 +434,7 @@ class execution(_Config):
 
         if cls._layout is None:
             import re
+            from bids.layout.index import BIDSLayoutIndexer
             from bids.layout import BIDSLayout
 
             if cls.bids_database_dir:
@@ -446,18 +447,26 @@ class execution(_Config):
                 _db_path = cls.work_dir / cls.run_uuid / "bids_db"
 
             _db_path.mkdir(exist_ok=True, parents=True)
-            cls._layout = BIDSLayout(
-                str(cls.bids_dir),
+
+            # Recommended after PyBIDS 12.1
+            _indexer = BIDSLayoutIndexer(
                 validate=False,
-                database_path=_db_path,
-                reset_database=cls.bids_database_dir is None,
                 ignore=(
                     "code",
                     "stimuli",
                     "sourcedata",
                     "models",
                     re.compile(r"^\."),
+                    re.compile(
+                        r"sub-[a-zA-Z0-9]+(/ses-[a-zA-Z0-9]+)?/(beh|dwi|eeg|ieeg|meg|perf)"
+                    ),
                 ),
+            )
+            cls._layout = BIDSLayout(
+                str(cls.bids_dir),
+                database_path=_db_path,
+                reset_database=cls.bids_database_dir is None,
+                indexer=_indexer,
             )
             cls.bids_database_dir = _db_path
         cls.layout = cls._layout

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     numpy
     pandas
     psutil >= 5.4
-    pybids >= 0.11.1
+    pybids >= 0.12.1
     pyyaml
     requests
     scikit-image ~= 0.17.2


### PR DESCRIPTION
Updates to the recommended way of initializer the indexer, and also
includes a new regex to preempt indexing unnecessary modalities as
@jdkent reported.

Resolves: #2386.
