### PR TITLE
ENH: Avoid eager imports from *NiWorkflows* causing API breaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,6 +234,7 @@ RUN conda install -y python=3.8 \
                      numpy=1.20 \
                      scipy=1.6 \
                      scikit-learn=0.24 \
+                     scikit-image=0.18 \
                      matplotlib=3.3 \
                      pandas=1.2 \
                      libxslt=1.1 \
@@ -259,12 +260,11 @@ RUN python -c "from matplotlib import font_manager" && \
     sed -i 's/\(backend *: \).*$/\1Agg/g' $( python -c "import matplotlib; print(matplotlib.matplotlib_fname())" )
 
 # Precaching atlases
-COPY setup.cfg fmriprep-setup.cfg
 COPY scripts/fetch_templates.py fetch_templates.py
 
-RUN pip install --no-cache-dir "$( grep templateflow fmriprep-setup.cfg | xargs )" && \
+RUN pip install --no-cache-dir templateflow && \
     python fetch_templates.py && \
-    rm fmriprep-setup.cfg fetch_templates.py && \
+    rm fetch_templates.py && \
     find $HOME/.cache/templateflow -type d -exec chmod go=u {} + && \
     find $HOME/.cache/templateflow -type f -exec chmod go=u {} +
 

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -1,33 +1,10 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-
-# Load modules for compatibility
-from niworkflows.interfaces import (
-    bids, cifti, freesurfer, images, itk, surf, utils)
-
-from .reports import SubjectSummary, FunctionalSummary, AboutSummary
-from .confounds import GatherConfounds, ICAConfounds, FMRISummary
-from .multiecho import T2SMap
+from niworkflows.interfaces.bids import DerivativesDataSink as _DDSink
 
 
-class DerivativesDataSink(bids.DerivativesDataSink):
+class DerivativesDataSink(_DDSink):
     out_path_base = ""
 
 
-__all__ = [
-    'bids',
-    'cifti',
-    'freesurfer',
-    'images',
-    'itk',
-    'surf',
-    'utils',
-    'SubjectSummary',
-    'FunctionalSummary',
-    'AboutSummary',
-    'GatherConfounds',
-    'ICAConfounds',
-    'FMRISummary',
-    'T2SMap',
-    'DerivativesDataSink',
-]
+__all__ = ("DerivativesDataSink",)

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -37,7 +37,8 @@ from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 
 from .. import config
-from ..interfaces import SubjectSummary, AboutSummary, DerivativesDataSink
+from ..interfaces import DerivativesDataSink
+from ..interfaces.reports import SubjectSummary, AboutSummary
 from .bold import init_func_preproc_wf
 
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -160,8 +160,7 @@ def init_func_preproc_wf(bold_file):
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.func.util import init_bold_reference_wf
     from niworkflows.interfaces.nibabel import ApplyMask
-    from niworkflows.interfaces.utility import KeySelect
-    from niworkflows.interfaces.utils import DictMerge
+    from niworkflows.interfaces.utility import KeySelect, DictMerge
     from sdcflows.workflows.base import init_sdc_estimate_wf, fieldmap_wrangler
 
     if nb.load(
@@ -939,7 +938,7 @@ def _get_wf_name(bold_fname):
 
 def _to_join(in_file, join_file):
     """Join two tsv files if the join_file is not ``None``."""
-    from niworkflows.interfaces.utils import JoinTSVColumns
+    from niworkflows.interfaces.utility import JoinTSVColumns
     if join_file is None:
         return in_file
     res = JoinTSVColumns(in_file=in_file, join_file=join_file).run()

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -147,7 +147,7 @@ def init_bold_confs_wf(
     from niworkflows.interfaces.confounds import ExpandModel, SpikeRegressors
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
     from niworkflows.interfaces.images import SignalExtraction
-    from niworkflows.interfaces.masks import ROIsPlot
+    from niworkflows.interfaces.reportlets.masks import ROIsPlot
     from niworkflows.interfaces.nibabel import ApplyMask, Binarize
     from niworkflows.interfaces.patches import (
         RobustACompCor as ACompCor,
@@ -156,7 +156,7 @@ def init_bold_confs_wf(
     from niworkflows.interfaces.plotting import (
         CompCorVariancePlot, ConfoundsCorrelationPlot
     )
-    from niworkflows.interfaces.utils import (
+    from niworkflows.interfaces.utility import (
         AddTSVHeader, TSV2JSON, DictMerge
     )
     from ...interfaces.confounds import aCompCorMasks
@@ -639,9 +639,8 @@ def init_ica_aroma_wf(
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.interfaces.segmentation import ICA_AROMARPT
-    from niworkflows.interfaces.utility import KeySelect
-    from niworkflows.interfaces.utils import TSV2JSON
+    from niworkflows.interfaces.reportlets.segmentation import ICA_AROMARPT
+    from niworkflows.interfaces.utility import KeySelect, TSV2JSON
 
     workflow = Workflow(name=name)
     workflow.__postdesc__ = """\

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -36,8 +36,9 @@ from nipype.pipeline import engine as pe
 from templateflow.api import get as get_template
 
 from ...config import DEFAULT_MEMORY_MIN_GB
-from ...interfaces import (
-    GatherConfounds, ICAConfounds, FMRISummary, DerivativesDataSink
+from ...interfaces import DerivativesDataSink
+from ...interfaces.confounds import (
+    GatherConfounds, ICAConfounds, FMRISummary,
 )
 
 

--- a/fmriprep/workflows/bold/hmc.py
+++ b/fmriprep/workflows/bold/hmc.py
@@ -79,7 +79,7 @@ def init_bold_hmc_wf(mem_gb, omp_nthreads, name='bold_hmc_wf'):
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.interfaces import NormalizeMotionParams
+    from niworkflows.interfaces.confounds import NormalizeMotionParams
     from niworkflows.interfaces.itk import MCFLIRT2ITK
 
     workflow = Workflow(name=name)

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -464,7 +464,7 @@ def init_bold_preproc_report_wf(mem_gb, reportlets_dir, name='bold_preproc_repor
     """
     from nipype.algorithms.confounds import TSNR
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.interfaces import SimpleBeforeAfter
+    from niworkflows.interfaces.reportlets.registration import SimpleBeforeAfterRPT
     from ...interfaces import DerivativesDataSink
 
     workflow = Workflow(name=name)
@@ -475,7 +475,7 @@ def init_bold_preproc_report_wf(mem_gb, reportlets_dir, name='bold_preproc_repor
     pre_tsnr = pe.Node(TSNR(), name='pre_tsnr', mem_gb=mem_gb * 4.5)
     pos_tsnr = pe.Node(TSNR(), name='pos_tsnr', mem_gb=mem_gb * 4.5)
 
-    bold_rpt = pe.Node(SimpleBeforeAfter(), name='bold_rpt',
+    bold_rpt = pe.Node(SimpleBeforeAfterRPT(), name='bold_rpt',
                        mem_gb=0.1)
     ds_report_bold = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir, desc='preproc',

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -280,7 +280,7 @@ def init_bold_t1_trans_wf(freesurfer, mem_gb, omp_nthreads, use_compression=True
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
     from niworkflows.interfaces.itk import MultiApplyTransforms
     from niworkflows.interfaces.nilearn import Merge
-    from niworkflows.interfaces.utils import GenerateSamplingReference
+    from niworkflows.interfaces.nibabel import GenerateSamplingReference
 
     workflow = Workflow(name=name)
     inputnode = pe.Node(
@@ -645,7 +645,7 @@ def init_fsl_bbr_wf(use_bbr, bold2t1w_dof, bold2t1w_init, sloppy=False, name='fs
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.utils.images import dseg_label as _dseg_label
     from niworkflows.interfaces.freesurfer import PatchedLTAConvert as LTAConvert
-    from niworkflows.interfaces.registration import FLIRTRPT
+    from niworkflows.interfaces.reportlets.registration import FLIRTRPT
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
 The BOLD reference was then co-registered to the T1w reference using

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -286,7 +286,7 @@ def init_bold_std_trans_wf(
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
     from niworkflows.interfaces.itk import MultiApplyTransforms
     from niworkflows.interfaces.utility import KeySelect
-    from niworkflows.interfaces.utils import GenerateSamplingReference
+    from niworkflows.interfaces.nibabel import GenerateSamplingReference
     from niworkflows.interfaces.nilearn import Merge
     from niworkflows.utils.spaces import format_reference
 

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -91,7 +91,7 @@ def init_bold_stc_wf(metadata, name='bold_stc_wf'):
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.interfaces.utils import CopyXForm
+    from niworkflows.interfaces.header import CopyXForm
 
     workflow = Workflow(name=name)
     workflow.__desc__ = """\

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -30,7 +30,7 @@ Generate T2* map from multi-echo BOLD images
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 
-from ...interfaces import T2SMap
+from ...interfaces.multiecho import T2SMap
 from ... import config
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,9 @@ install_requires =
     pybids >= 0.11.1
     pyyaml
     requests
-    scikit-image ~= 0.17.2
-    sdcflows ~= 1.3.2
-    smriprep ~= 0.7.0
+    scikit-image >= 0.17.2, < 0.19
+    sdcflows @ git+https://github.com/nipreps/sdcflows.git@maint/niworkflows-1.4-bridge
+    smriprep @ git+https://github.com/nipreps/smriprep.git@master
     tedana ~= 0.0.9
     templateflow >= 0.6
     toml
@@ -64,7 +64,7 @@ docs =
     %(doc)s
 duecredit = duecredit
 resmon =
-sentry = sentry-sdk >=0.6.9
+sentry = sentry-sdk ~= 1.3.0
 tests =
     coverage
     codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nipype >= 1.5.1
     nitime
     nitransforms >= 20.0.0rc3, < 20.2
-    niworkflows ~= 1.3.2
+    niworkflows @ git+https://github.com/nipreps/niworkflows.git@master
     numpy
     pandas
     psutil >= 5.4


### PR DESCRIPTION
Removes the preloading of interfaces at ``__init__`` of the interfaces submodule.