### PR TITLE
ENH: Add flag for STC reference time and set in all cases

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -85,7 +85,7 @@ def _build_parser():
         if value == "start":
             value = 0
         elif value == "middle":
-            value = 1
+            value = 0.5
         try:
             value = float(value)
         except ValueError:

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -87,10 +87,13 @@ def _build_parser():
         elif value == "middle":
             value = 1
         try:
-            return float(value)
+            value = float(value)
         except ValueError:
             raise parser.error("Slice time reference must be number, 'start', or 'middle'. "
                                f"Received {value}.")
+        if not 0 <= val <= 1:
+            raise parser.error(f"Slice time reference must be in range 0-1. Received {value}.")
+        return value
 
 
     verstr = f"fMRIPrep v{config.environment.version}"

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -81,6 +81,18 @@ def _build_parser():
         if value and Path(value).exists():
             return loads(Path(value).read_text(), object_hook=_filter_pybids_none_any)
 
+    def _slice_time_ref(value, parser):
+        if value == "start":
+            value = 0
+        elif value == "middle":
+            value = 1
+        try:
+            return float(value)
+        except ValueError:
+            raise parser.error("Slice time reference must be number, 'start', or 'middle'. "
+                               f"Received {value}.")
+
+
     verstr = f"fMRIPrep v{config.environment.version}"
     currentv = Version(config.environment.version)
     is_release = not any(
@@ -328,6 +340,17 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         default=False,
         help="Replace medial wall values with NaNs on functional GIFTI files. Only "
         "performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).",
+    )
+    g_conf.add_argument(
+        "--slice-time-ref",
+        required=False,
+        action="store",
+        default=None,
+        type=_slice_time_ref,
+        help="The time of the reference slice to correct BOLD values to, as a fraction "
+             "acquisition time. 0 indicates the start, 0.5 the midpoint, and 1 the end "
+             "of acquisition. The alias `start` corresponds to 0, and `middle` to 0.5. "
+             "The default value is 0.5.",
     )
     g_conf.add_argument(
         "--dummy-scans",

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -550,6 +550,11 @@ class workflow(_Config):
     skull_strip_t1w = "force"
     """Skip brain extraction of the T1w image (default is ``force``, meaning that
     *fMRIPrep* will run brain extraction of the T1w)."""
+    slice_time_ref = 0.5
+    """The time of the reference slice to correct BOLD values to, as a fraction
+    acquisition time. 0 indicates the start, 0.5 the midpoint, and 1 the end
+    of acquisition. The alias `start` corresponds to 0, and `middle` to 0.5.
+    The default value is 0.5."""
     spaces = None
     """Keeps the :py:class:`~niworkflows.utils.spaces.SpatialReferences`
     instance keeping standard and nonstandard spaces."""

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -107,7 +107,7 @@ BOLD runs were slice-time corrected to {tzero:0.3g}s ({frac:g} of slice acquisit
     inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file', 'skip_vols']), name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(fields=['stc_file']), name='outputnode')
 
-    LOGGER.log(25, f'BOLD series will be slice-timing corrected to an offset of {tzero:.3g}.')
+    LOGGER.log(25, f'BOLD series will be slice-timing corrected to an offset of {tzero:.3g}s.')
 
     # It would be good to fingerprint memory use of afni.TShift
     slice_timing_correction = pe.Node(

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -96,7 +96,7 @@ def init_bold_stc_wf(metadata, name='bold_stc_wf'):
     slice_times = metadata["SliceTiming"]
     first, last = min(slice_times), max(slice_times)
     frac = config.workflow.slice_time_ref
-    tzero = first + frac * (last - first)
+    tzero = np.round(first + frac * (last - first), 3)
 
     afni_ver = ''.join('%02d' % v for v in afni.Info().version() or [])
     workflow = Workflow(name=name)

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -107,7 +107,7 @@ BOLD runs were slice-time corrected to {tzero:0.3g}s ({frac:g} of slice acquisit
     inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file', 'skip_vols']), name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(fields=['stc_file']), name='outputnode')
 
-    LOGGER.log(25, 'Slice-timing correction will be included.')
+    LOGGER.log(25, f'BOLD series will be slice-timing corrected to an offset of {tzero:.3g}.')
 
     # It would be good to fingerprint memory use of afni.TShift
     slice_timing_correction = pe.Node(


### PR DESCRIPTION
This PR partially address #2477 by providing a flag `--slice-time-ref` that can take a float from 0-1 or special values `"first"` and `"middle"`.

This also always sets the `-tzero` flag for 3dTshift (in cases where we run STC) to `min + frac * (max - min)`, which will generally be `frac * max`. This *should* be the same as 3dTshift's default of `mean(SliceTiming)`, as well as `frac * max`, but I update the text to be explicit as well.

Millisecond precision is used in reporting.

Closes #2516.