### PR TITLE
ENH: Add SliceTimingCorrected and StartTime fields to BOLD metadata

### DIFF
--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -42,19 +42,45 @@ def prepare_timing_parameters(metadata):
     Examples
     --------
 
+    .. testsetup::
+
+        >>> from unittest import mock
+
+    If SliceTiming metadata is absent, then the only change is to note that
+    STC has not been applied:
+
     >>> prepare_timing_parameters(dict(RepetitionTime=2))
-    {'RepetitionTime': 2}
+    {'RepetitionTime': 2, 'SliceTimingCorrected': False}
     >>> prepare_timing_parameters(dict(RepetitionTime=2, DelayTime=0.5))
-    {'RepetitionTime': 2, 'DelayTime': 0.5}
-    >>> prepare_timing_parameters(dict(RepetitionTime=2, SliceTiming=[0.0, 0.2, 0.4, 0.6]))
-    {'RepetitionTime': 2, 'DelayTime': 1.2}
+    {'RepetitionTime': 2, 'DelayTime': 0.5, 'SliceTimingCorrected': False}
     >>> prepare_timing_parameters(dict(VolumeTiming=[0.0, 1.0, 2.0, 5.0, 6.0, 7.0],
     ...                                AcquisitionDuration=1.0))
-    {'VolumeTiming': [0.0, 1.0, 2.0, 5.0, 6.0, 7.0], 'AcquisitionDuration': 1.0}
-    >>> prepare_timing_parameters(dict(VolumeTiming=[0.0, 1.0, 2.0, 5.0, 6.0, 7.0],
-    ...                                SliceTiming=[0.0, 0.2, 0.4, 0.6, 0.8]))
-    {'VolumeTiming': [0.0, 1.0, 2.0, 5.0, 6.0, 7.0], 'AcquisitionDuration': 1.0}
+    {'VolumeTiming': [0.0, 1.0, 2.0, 5.0, 6.0, 7.0], 'AcquisitionDuration': 1.0,
+     'SliceTimingCorrected': False}
 
+    When SliceTiming is available and used, then ``SliceTimingCorrected`` is ``True``
+    and the ``StartTime`` indicates a series offset.
+
+    >>> with mock.patch("fmriprep.config.workflow.ignore", []):
+    ...     prepare_timing_parameters(dict(RepetitionTime=2, SliceTiming=[0.0, 0.2, 0.4, 0.6]))
+    {'RepetitionTime': 2, 'SliceTimingCorrected': True, 'DelayTime': 1.2, 'StartTime': 0.3}
+    >>> with mock.patch("fmriprep.config.workflow.ignore", []):
+    ...     prepare_timing_parameters(dict(VolumeTiming=[0.0, 1.0, 2.0, 5.0, 6.0, 7.0],
+    ...                                    SliceTiming=[0.0, 0.2, 0.4, 0.6, 0.8]))
+    {'VolumeTiming': [0.0, 1.0, 2.0, 5.0, 6.0, 7.0], 'SliceTimingCorrected': True,
+     'AcquisitionDuration': 1.0, 'StartTime': 0.4}
+
+    When SliceTiming is available and not used, then ``SliceTimingCorrected`` is ``False``
+    and TA is indicated with ``DelayTime`` or ``AcquisitionDuration``.
+
+    >>> with mock.patch("fmriprep.config.workflow.ignore", ["slicetiming"]):
+    ...     prepare_timing_parameters(dict(RepetitionTime=2, SliceTiming=[0.0, 0.2, 0.4, 0.6]))
+    {'RepetitionTime': 2, 'SliceTimingCorrected': False, 'DelayTime': 1.2}
+    >>> with mock.patch("fmriprep.config.workflow.ignore", ["slicetiming"]):
+    ...     prepare_timing_parameters(dict(VolumeTiming=[0.0, 1.0, 2.0, 5.0, 6.0, 7.0],
+    ...                                    SliceTiming=[0.0, 0.2, 0.4, 0.6, 0.8]))
+    {'VolumeTiming': [0.0, 1.0, 2.0, 5.0, 6.0, 7.0], 'SliceTimingCorrected': False,
+     'AcquisitionDuration': 1.0}
     """
     timing_parameters = {
         key: metadata[key]

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -62,6 +62,9 @@ def prepare_timing_parameters(metadata):
                     "AcquisitionDuration", "SliceTiming")
         if key in metadata}
 
+    run_stc = "SliceTiming" in metadata and 'slicetiming' not in config.workflow.ignore
+    timing_parameters["SliceTimingCorrected"] = run_stc
+
     if "SliceTiming" in timing_parameters:
         st = sorted(timing_parameters.pop("SliceTiming"))
         TA = st[-1] + (st[1] - st[0])  # Final slice onset - slice duration
@@ -73,6 +76,13 @@ def prepare_timing_parameters(metadata):
         # For variable TR paradigms, use AcquisitionDuration
         elif "VolumeTiming" in timing_parameters:
             timing_parameters["AcquisitionDuration"] = TA
+
+        if run_stc:
+            first, last = st[0], st[-1]
+            frac = config.workflow.slice_time_ref
+            tzero = np.round(first + frac * (last - first), 3)
+            timing_parameters["StartTime"] = tzero
+
     return timing_parameters
 
 


### PR DESCRIPTION
## Changes proposed in this pull request

Closes #2539.
Addresses #2477.
Implements provisional https://github.com/bids-standard/bids-specification/issues/836

This does not update the `toffset` field in NIfTI at present.

One thing to address: when we're calculating the acquisition time (TA), we use `st[-1] + (st[1] - st[0])`, which treats each slice as having a duration. When we're calculating tzero, we use `(st[-1] - st[0]) * frac + st[0]`, which treats each slice as an instantaneous acquisition. So tzero is a half "slice duration" less than half TA (`tzero = (t[0] + TA) / 2 - (t[1] - t[0]) / 2`).

Our tzero calculation is consistent with AFNI's default, but while we're here, maybe we want to adjust it to be `tzero = (t[0] + TA) / 2`. Or is the calculation of TA incorrect?

cc @martinhebert @theoschaefer @nitschalex @oliver-contier @kellyhennigan

