### PR TITLE
FIX: Propagate the SDC warp to resampling node also with ME

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -1101,17 +1101,16 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (("outputnode.fieldwarp", _pop), "inputnode.fieldwarp"),
         ]),
         (unwarp_wf, bold_final, [("outputnode.corrected", "bold")]),
-
+        (unwarp_wf, bold_t1_trans_wf, [
+            # TEMPORARY: For the moment we can't use frame-wise fieldmaps
+            (("outputnode.fieldwarp", _pop), "inputnode.fieldwarp"),
+        ]),
     ])
     # fmt:on
 
     if not multiecho:
         # fmt:off
         workflow.connect([
-            (unwarp_wf, bold_t1_trans_wf, [
-                # TEMPORARY: For the moment we can't use frame-wise fieldmaps
-                (("outputnode.fieldwarp", _pop), "inputnode.fieldwarp"),
-            ]),
             (bold_split, unwarp_wf, [
                 ("out_files", "inputnode.distorted")]),
         ])


### PR DESCRIPTION
This connection can (should) be shared by both the SE and the ME paths. That said, *SDCFlows* needs to be revised (nipreps/sdcflows#245) so that fieldmaps without HMC are generated (and remove that ``_pop`` from this connection).

Amends: #2576.