### PR TITLE
RF: Add extension field to differentiate from upcoming templates

### DIFF
--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -629,7 +629,7 @@ surface space.
                 density='164k',
                 desc='std',
                 suffix='sphere',
-                extension=['.surf.gii']
+                extension='.surf.gii',
             )
         )
         for hemi in 'LR'
@@ -642,7 +642,7 @@ surface space.
                 density='164k',
                 desc='vaavg',
                 suffix='midthickness',
-                extension=['.shape.gii']
+                extension='.shape.gii',
             )
         )
         for hemi in 'LR'
@@ -655,7 +655,7 @@ surface space.
                 hemi=hemi,
                 density=fslr_density,
                 suffix='sphere',
-                extension=['.surf.gii']
+                extension='.surf.gii',
             )
         )
         for hemi in 'LR'
@@ -668,7 +668,7 @@ surface space.
                 density=fslr_density,
                 desc='vaavg',
                 suffix='midthickness',
-                extension=['.shape.gii']
+                extension='.shape.gii',
             )
         )
         for hemi in 'LR'


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Adds the `extension` field to `templateflow.api.get` queries.
This will avoid fetching upcoming additions to TemplateFlow's `fsLR` files. 
<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
