### PR TITLE
FIX: Add `-basescale 1` parameter to avoid `flirt` scaling

### DIFF
--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -652,7 +652,8 @@ for distortions remaining in the BOLD reference.
     wm_mask = pe.Node(niu.Function(function=_dseg_label), name='wm_mask')
     wm_mask.inputs.label = 2  # BIDS default is WM=2
     flt_bbr_init = pe.Node(FLIRTRPT(dof=6, generate_report=not use_bbr,
-                                    uses_qform=True), name='flt_bbr_init')
+                                    uses_qform=True, args="-basescale 1"),
+                           name='flt_bbr_init')
 
     if bold2t1w_init not in ("register", "header"):
         raise ValueError(f"Unknown BOLD-T1w initialization option: {bold2t1w_init}")
@@ -694,7 +695,7 @@ for distortions remaining in the BOLD reference.
         return workflow
 
     flt_bbr = pe.Node(
-        FLIRTRPT(cost_func='bbr', dof=bold2t1w_dof, generate_report=True),
+        FLIRTRPT(cost_func='bbr', dof=bold2t1w_dof, args="-basescale 1", generate_report=True),
         name='flt_bbr')
 
     FSLDIR = os.getenv('FSLDIR')


### PR DESCRIPTION
- Disables `flirt` scaling of input transformation matrices, which may
  lead to issues with high-resolution T1w data (see #2591)

This is #2607 without the switch to `mri_coreg`. That can be done in 21.0.0.

Doing this first so we can get the mri_coreg fix into the next 21.0 RC.

cc @HippocampusGirl 