### PR TITLE
ENH: Replace initial FLIRT with mri_coreg, use -basescale 1 for FLIRT-BBR

### DIFF
--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -99,10 +99,11 @@ sections:
     static: false
     subtitle: Experimental fieldmap-less susceptibility distortion correction
   - bids: {datatype: figures, desc: flirtnobbr, suffix: bold}
-    caption: FSL <code>flirt</code> was used to generate transformations from EPI
-      space to T1 Space - BBR refinement rejected. Note that Nearest Neighbor interpolation
-      is used in the reportlets in order to highlight potential spin-history and other
-      artifacts, whereas final images are resampled using Lanczos interpolation.
+    caption: <code>mri_coreg</code> (FreeSurfer) was used to generate transformations
+      from EPI space to T1 Space - BBR refinement using FSL <code>flirt</code> rejected.
+      Note that Nearest Neighbor interpolation is used in the reportlets in order to
+      highlight potential spin-history and other artifacts, whereas final images are
+      resampled using Lanczos interpolation.
     static: false
     subtitle: Alignment of functional and anatomical MRI data (volume based)
   - bids: {datatype: figures, desc: coreg, suffix: bold}

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -728,7 +728,7 @@ for distortions remaining in the BOLD reference.
         return workflow
 
     flt_bbr = pe.Node(
-        FLIRTRPT(cost_func='bbr', dof=bold2t1w_dof, generate_report=True),
+        FLIRTRPT(cost_func='bbr', dof=bold2t1w_dof, args="-basescale 1", generate_report=True),
         name='flt_bbr')
 
     FSLDIR = os.getenv('FSLDIR')

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -658,11 +658,13 @@ def init_fsl_bbr_wf(use_bbr, bold2t1w_dof, bold2t1w_init, omp_nthreads, sloppy=F
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
 The BOLD reference was then co-registered to the T1w reference using
-`flirt` [FSL {fsl_ver}, @flirt] with the boundary-based registration [@bbr]
-cost-function.
-Co-registration was configured with nine degrees of freedom to account
-for distortions remaining in the BOLD reference.
-""".format(fsl_ver=FLIRTRPT().version or '<ver>')
+`mri_coreg` (FreeSurfer) followed by `flirt` [FSL {fsl_ver}, @flirt]
+with the boundary-based registration [@bbr] cost-function.
+Co-registration was configured with {dof} degrees of freedom{reason}.
+""".format(fsl_ver=FLIRTRPT().version or '<ver>',
+           dof={6: 'six', 9: 'nine', 12: 'twelve'}[bold2t1w_dof],
+           reason='' if bold2t1w_dof == 6 else
+                  'to account for distortions remaining in the BOLD reference')
 
     inputnode = pe.Node(
         niu.IdentityInterface([


### PR DESCRIPTION
Rebases #2607 on master.

Fast-tracked to get this into the next 21.0.0 RC. Need to figure out numpy failures in the docker image to patch 20.2.x.