### PR TITLE
RF/FIX: Iterate over echo indices, not filenames, simplifying iteration logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -900,7 +900,7 @@ jobs:
                 --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
                 /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
                 ${FASTRACK_ARG} \
-                --output-layout legacy \
+                --output-layout legacy --me-output-echos \
                 --fs-no-reconall --use-syn-sdc --ignore slicetiming \
                 --dummy-scans 1 --sloppy --write-graph \
                 --output-spaces MNI152NLin2009cAsym \

--- a/.circleci/ds210_fasttrack_outputs.txt
+++ b/.circleci/ds210_fasttrack_outputs.txt
@@ -16,6 +16,12 @@ fmriprep/sub-02/fmap/sub-02_run-1_fmapid-auto00000_desc-preproc_fieldmap.nii.gz
 fmriprep/sub-02/func
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_desc-confounds_timeseries.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_desc-confounds_timeseries.tsv
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-1_desc-preproc_bold.json
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-1_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-2_desc-preproc_bold.json
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-2_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-3_desc-preproc_bold.json
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-3_desc-preproc_bold.nii.gz
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_from-scanner_to-T1w_mode-image_xfm.txt
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_from-T1w_to-scanner_mode-image_xfm.txt
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_space-MNI152NLin2009cAsym_boldref.nii.gz

--- a/.circleci/ds210_outputs.txt
+++ b/.circleci/ds210_outputs.txt
@@ -35,6 +35,12 @@ fmriprep/sub-02/fmap/sub-02_run-1_fmapid-auto00000_desc-preproc_fieldmap.nii.gz
 fmriprep/sub-02/func
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_desc-confounds_timeseries.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_desc-confounds_timeseries.tsv
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-1_desc-preproc_bold.json
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-1_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-2_desc-preproc_bold.json
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-2_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-3_desc-preproc_bold.json
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_echo-3_desc-preproc_bold.nii.gz
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_from-scanner_to-T1w_mode-image_xfm.txt
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_from-T1w_to-scanner_mode-image_xfm.txt
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-1_space-MNI152NLin2009cAsym_boldref.nii.gz

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -557,9 +557,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ("outputnode.raw_ref_image", "inputnode.raw_ref_image"),
             ("outputnode.bold_file", "inputnode.bold_file"),
         ]),
-        (initial_boldref_wf, summary, [
-            ("outputnode.algo_dummy_scans", "algo_dummy_scans"),
-        ]),
         # EPI-T1w registration workflow
         (inputnode, bold_reg_wf, [
             ("t1w_dseg", "inputnode.t1w_dseg"),
@@ -595,7 +592,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ("outputnode.bold_aseg_t1", "bold_aseg_t1"),
             ("outputnode.bold_aparc_t1", "bold_aparc_t1"),
         ]),
-        (bold_reg_wf, summary, [("outputnode.fallback", "fallback")]),
         # Connect bold_confounds_wf
         (inputnode, bold_confounds_wf, [
             ("t1w_tpms", "inputnode.t1w_tpms"),
@@ -636,6 +632,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ("bold_echos", "bold_echos_native"),
         ]),
         # Summary
+        (initial_boldref_wf, summary, [("outputnode.algo_dummy_scans", "algo_dummy_scans")]),
+        (bold_reg_wf, summary, [("outputnode.fallback", "fallback")]),
         (outputnode, summary, [("confounds", "confounds_file")]),
         # Select echo indices for original/validated BOLD files
         (echo_index, bold_source, [("echoidx", "index")]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -549,7 +549,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (inputnode, t1w_brain, [("t1w_preproc", "in_file"),
                                 ("t1w_mask", "in_mask")]),
         # Select validated bold files per-echo
-        (initial_boldref_wf, validated_bold, [("outputnode.bold_file", "inlist")]),
+        (initial_boldref_wf, validated_bold, [("val_bold.out_file", "inlist")]),
         # BOLD buffer has slice-time corrected if it was run, original otherwise
         (boldbuffer, bold_split, [("bold_file", "in_file")]),
         # HMC

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -549,7 +549,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (inputnode, t1w_brain, [("t1w_preproc", "in_file"),
                                 ("t1w_mask", "in_mask")]),
         # Select validated bold files per-echo
-        (initial_boldref_wf, validated_bold, [("val_bold.out_file", "inlist")]),
+        (initial_boldref_wf, validated_bold, [("outputnode.all_bold_files", "inlist")]),
         # BOLD buffer has slice-time corrected if it was run, original otherwise
         (boldbuffer, bold_split, [("bold_file", "in_file")]),
         # HMC

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -362,10 +362,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
     # BOLD buffer: an identity used as a pointer to either the original BOLD
     # or the STC'ed one for further use.
-    boldbuffer = pe.Node(niu.IdentityInterface(fields=["bold_file", "name_source"]),
-                         name="boldbuffer")
-    if multiecho:
-        boldbuffer.synchronize = True
+    boldbuffer = pe.Node(niu.IdentityInterface(fields=["bold_file"]), name="boldbuffer")
 
     summary = pe.Node(
         FunctionalSummary(
@@ -503,12 +500,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             meepi_echos = boldbuffer.clone(name="meepi_echos")
             meepi_echos.iterables = [
                 ("bold_file", bold_file),
-                ("name_source", bold_file),
             ]
             # fmt:off
             workflow.connect([
                 (meepi_echos, bold_stc_wf, [("bold_file", "inputnode.bold_file")]),
-                (meepi_echos, boldbuffer, [("name_source", "name_source")]),
             ])
             # fmt:on
 
@@ -523,7 +518,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         # for meepi, iterate over all meepi echos to boldbuffer
         boldbuffer.iterables = [
             ("bold_file", bold_file),
-            ("name_source", bold_file),
         ]
 
     # MULTI-ECHO EPI DATA #############################################
@@ -1022,7 +1016,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ("outputnode.bold_mask", "inputnode.bold_mask"),
             ]),
             (boldbuffer, bold_bold_trans_wf, [
-                ("name_source", "inputnode.name_source"),
+                ("bold_file", "inputnode.name_source"),
             ]),
             (bold_bold_trans_wf, join_echos, [
                 ("outputnode.bold", "bold_files"),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -360,6 +360,17 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     # Generate a brain-masked conversion of the t1w
     t1w_brain = pe.Node(ApplyMask(), name="t1w_brain")
 
+    # Track echo index - this allows us to treat multi- and single-echo workflows
+    # almost identically
+    echo_index = pe.Node(niu.IdentityInterface(fields=["echoidx"]), name="echo_index")
+    if multiecho:
+        echo_index.iterables = [("echoidx", range(len(bold_file)))]
+    else:
+        echo_index.inputs.echoidx = 0
+
+    # BOLD source: track original BOLD file(s)
+    bold_source = pe.Node(niu.Select(inlist=bold_file), name="bold_source")
+
     # BOLD buffer: an identity used as a pointer to either the original BOLD
     # or the STC'ed one for further use.
     boldbuffer = pe.Node(niu.IdentityInterface(fields=["bold_file"]), name="boldbuffer")
@@ -433,6 +444,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     )
     initial_boldref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 
+    # Select validated BOLD files (orientations checked or corrected)
+    validated_bold = pe.Node(niu.Select(), name="validated_bold")
+
     # Top-level BOLD splitter
     bold_split = pe.Node(
         FSLSplit(dimension="t"), name="bold_split", mem_gb=mem_gb["filesize"] * 3
@@ -483,42 +497,15 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         bold_stc_wf = init_bold_stc_wf(name="bold_stc_wf", metadata=metadata)
         # fmt:off
         workflow.connect([
-            (initial_boldref_wf, bold_stc_wf, [
-                ("outputnode.skip_vols", "inputnode.skip_vols")]),
+            (initial_boldref_wf, bold_stc_wf, [("outputnode.skip_vols", "inputnode.skip_vols")]),
+            (validated_bold, bold_stc_wf, [("out", "inputnode.bold_file")]),
             (bold_stc_wf, boldbuffer, [("outputnode.stc_file", "bold_file")]),
         ])
         # fmt:on
-        if not multiecho:
-            # fmt:off
-            workflow.connect([
-                (initial_boldref_wf, bold_stc_wf, [
-                    ("outputnode.bold_file", "inputnode.bold_file"),
-                ])
-            ])
-            # fmt:on
-        else:  # for meepi, iterate through stc_wf for all workflows
-            meepi_echos = boldbuffer.clone(name="meepi_echos")
-            meepi_echos.iterables = [
-                ("bold_file", bold_file),
-            ]
-            # fmt:off
-            workflow.connect([
-                (meepi_echos, bold_stc_wf, [("bold_file", "inputnode.bold_file")]),
-            ])
-            # fmt:on
 
     # bypass STC from original BOLD in both SE and ME cases
-    elif not multiecho:  # SE and skip-STC
-        # fmt:off
-        workflow.connect([
-            (initial_boldref_wf, boldbuffer, [("outputnode.bold_file", "bold_file")]),
-        ])
-        # fmt:on
-    else:  # ME and skip-STC
-        # for meepi, iterate over all meepi echos to boldbuffer
-        boldbuffer.iterables = [
-            ("bold_file", bold_file),
-        ]
+    else:
+        workflow.connect([(validated_bold, boldbuffer, [("out", "bold_file")])])
 
     # MULTI-ECHO EPI DATA #############################################
     if multiecho:  # instantiate relevant interfaces, imports
@@ -528,7 +515,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
         join_echos = pe.JoinNode(
             niu.IdentityInterface(fields=["bold_files"]),
-            joinsource=("meepi_echos" if run_stc is True else "boldbuffer"),
+            joinsource="echo_index",
             joinfield=["bold_files"],
             name="join_echos",
         )
@@ -558,8 +545,11 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     # MAIN WORKFLOW STRUCTURE #######################################################
     # fmt:off
     workflow.connect([
+        # Prepare masked T1w image
         (inputnode, t1w_brain, [("t1w_preproc", "in_file"),
                                 ("t1w_mask", "in_mask")]),
+        # Select validated bold files per-echo
+        (initial_boldref_wf, validated_bold, [("outputnode.bold_file", "inlist")]),
         # BOLD buffer has slice-time corrected if it was run, original otherwise
         (boldbuffer, bold_split, [("bold_file", "in_file")]),
         # HMC
@@ -647,6 +637,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         ]),
         # Summary
         (outputnode, summary, [("confounds", "confounds_file")]),
+        # Select echo indices for original/validated BOLD files
+        (echo_index, bold_source, [("echoidx", "index")]),
+        (echo_index, validated_bold, [("echoidx", "index")]),
     ])
     # fmt:on
 
@@ -994,12 +987,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         )
         bold_bold_trans_wf.inputs.inputnode.fieldwarp = "identity"
 
-        if not multiecho:
-            bold_bold_trans_wf.inputs.inputnode.name_source = ref_file
-
         # fmt:off
         workflow.connect([
             # Connect bold_bold_trans_wf
+            (bold_source, bold_bold_trans_wf, [("out", "inputnode.name_source")]),
             (bold_split, bold_bold_trans_wf, [("out_files", "inputnode.bold_file")]),
             (bold_hmc_wf, bold_bold_trans_wf, [
                 ("outputnode.xforms", "inputnode.hmc_xforms"),
@@ -1014,9 +1005,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         ] if not multiecho else [
             (initial_boldref_wf, bold_t2s_wf, [
                 ("outputnode.bold_mask", "inputnode.bold_mask"),
-            ]),
-            (boldbuffer, bold_bold_trans_wf, [
-                ("bold_file", "inputnode.name_source"),
             ]),
             (bold_bold_trans_wf, join_echos, [
                 ("outputnode.bold", "bold_files"),
@@ -1144,7 +1132,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 "corrected_mask",
             ]
         ),
-        joinsource=("meepi_echos" if run_stc is True else "boldbuffer"),
+        joinsource="echo_index",
         joinfield=[
             "fieldmap",
             "fieldwarp",

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -445,7 +445,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     initial_boldref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 
     # Select validated BOLD files (orientations checked or corrected)
-    validated_bold = pe.Node(niu.Select(), name="validated_bold")
+    select_bold = pe.Node(niu.Select(), name="select_bold")
 
     # Top-level BOLD splitter
     bold_split = pe.Node(
@@ -498,14 +498,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         # fmt:off
         workflow.connect([
             (initial_boldref_wf, bold_stc_wf, [("outputnode.skip_vols", "inputnode.skip_vols")]),
-            (validated_bold, bold_stc_wf, [("out", "inputnode.bold_file")]),
+            (select_bold, bold_stc_wf, [("out", "inputnode.bold_file")]),
             (bold_stc_wf, boldbuffer, [("outputnode.stc_file", "bold_file")]),
         ])
         # fmt:on
 
     # bypass STC from original BOLD in both SE and ME cases
     else:
-        workflow.connect([(validated_bold, boldbuffer, [("out", "bold_file")])])
+        workflow.connect([(select_bold, boldbuffer, [("out", "bold_file")])])
 
     # MULTI-ECHO EPI DATA #############################################
     if multiecho:  # instantiate relevant interfaces, imports
@@ -549,7 +549,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (inputnode, t1w_brain, [("t1w_preproc", "in_file"),
                                 ("t1w_mask", "in_mask")]),
         # Select validated bold files per-echo
-        (initial_boldref_wf, validated_bold, [("outputnode.all_bold_files", "inlist")]),
+        (initial_boldref_wf, select_bold, [("outputnode.all_bold_files", "inlist")]),
         # BOLD buffer has slice-time corrected if it was run, original otherwise
         (boldbuffer, bold_split, [("bold_file", "in_file")]),
         # HMC
@@ -637,7 +637,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (outputnode, summary, [("confounds", "confounds_file")]),
         # Select echo indices for original/validated BOLD files
         (echo_index, bold_source, [("echoidx", "index")]),
-        (echo_index, validated_bold, [("echoidx", "index")]),
+        (echo_index, select_bold, [("echoidx", "index")]),
     ])
     # fmt:on
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     nibabel >= 3.0
     nipype >= 1.5.1
     nitransforms ~= 21.0.0
-    niworkflows ~= 1.4.3
+    niworkflows ~= 1.4.4
     numpy
     pandas
     psutil >= 5.4


### PR DESCRIPTION
This PR:

1) Changes the source of iteration from `boldbuffer`/`meepi_echos` to `echo_index`, an `IdentityInterface` that is just `0` for single-echo workflows.
2) The echo index is passed to `bold_source` which indexes the list of BOLD images, and `validated_bold`, which indexes the list of BOLD images that have been validated in `initial_boldref_wf`.

Consequences:

1) Validated echos are now passed to STC/boldbuffer (was true for SE, but not for ME)
1) STC no longer has any dependency on number of echos
1) JoinNodes `joinsource` no longer depends on STC (non-)use
1) Iterable directories are now indexed by an integer instead of full file paths
1) `bold_bold_trans_wf` `name_source` no longer depends on number of echos

Fixes #2650.