### PR TITLE
FIX: Re-group and space boilerplate text

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -356,8 +356,7 @@ It is released under the [CC0]\
 
     # Append the functional section to the existing anatomical exerpt
     # That way we do not need to stream down the number of bold datasets
-    anat_preproc_wf.__postdesc__ = (anat_preproc_wf.__postdesc__ or '') + """
-
+    func_pre_desc = """
 Functional data preprocessing
 
 : For each of the {num_bold} BOLD runs found per subject (across all
@@ -371,6 +370,7 @@ tasks and sessions), the following preprocessing was performed.
         if func_preproc_wf is None:
             continue
 
+        func_preproc_wf.__desc__ = func_pre_desc + (func_preproc_wf.__desc__ or "")
         workflow.connect([
             (anat_preproc_wf, func_preproc_wf,
              [('outputnode.t1w_preproc', 'inputnode.t1w_preproc'),
@@ -403,6 +403,7 @@ tasks and sessions), the following preprocessing was performed.
         subject=subject_id,
     )
     fmap_wf.__desc__ = f"""
+
 Preprocessing of B<sub>0</sub> inhomogeneity mappings
 
 : A total of {len(fmap_estimators)} fieldmaps were found available within the input

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -30,7 +30,7 @@ __bugreports__ = 'https://github.com/nipreps/fmriprep/issues'
 MISSING = """
 Image '{}' is missing
 Would you like to download? [Y/n] """
-PKG_PATH = '/usr/local/miniconda/lib/python3.8/site-packages'
+PKG_PATH = '/opt/conda/lib/python3.8/site-packages'
 TF_TEMPLATES = (
     'MNI152Lin',
     'MNI152NLin2009cAsym',


### PR DESCRIPTION
The big issue was that the functional heading was attached to the anat postproc. Prepending it to all functional workflows ensures that it's always kept local. The fmap workflow needs an extra newline to be placed correctly, as well.

While testing this, I ran across the problem that the PKG_PATH in the wrapper didn't keep up with the changes in the docker file. I thought I'd fixed that in another PR, but I either never included it or it hasn't been merged yet.

Closes #2526.