### PR TITLE
MNT: Update scikit-image to 0.19 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -261,7 +261,8 @@ RUN curl -sSLO https://www.humanconnectome.org/storage/app/media/workbench/workb
 ENV PATH="/opt/workbench/bin_linux64:$PATH" \
     LD_LIBRARY_PATH="/opt/workbench/lib_linux64:$LD_LIBRARY_PATH"
 
-COPY --from=nipreps/miniconda@sha256:4d0dc0fabb794e9fe22ee468ae5f86c2c8c2b4cd9d7b7fdf0c134d9e13838729 /opt/conda /opt/conda
+# nipreps/miniconda:py38_1.4.1
+COPY --from=nipreps/miniconda@sha256:ebbff214e6c9dc50ccc6fdbe679df1ffcbceaa45b47a75d6e34e8a064ef178da /opt/conda /opt/conda
 
 RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
@@ -274,9 +275,6 @@ ENV PATH="/opt/conda/bin:$PATH" \
     LANG="C.UTF-8" \
     LC_ALL="C.UTF-8" \
     PYTHONNOUSERSITE=1
-
-# TMP: Upgrade scikit-image until it is updated in nipreps/miniconda image
-RUN /opt/conda/bin/conda install -n base -c conda-forge scikit-image=0.19
 
 # Unless otherwise specified each process should only use one thread - nipype
 # will handle parallelization

--- a/Dockerfile
+++ b/Dockerfile
@@ -275,6 +275,9 @@ ENV PATH="/opt/conda/bin:$PATH" \
     LC_ALL="C.UTF-8" \
     PYTHONNOUSERSITE=1
 
+# TMP: Upgrade scikit-image until it is updated in nipreps/miniconda image
+RUN /opt/conda/bin/conda install -n base -c conda-forge scikit-image=0.19
+
 # Unless otherwise specified each process should only use one thread - nipype
 # will handle parallelization
 ENV MKL_NUM_THREADS=1 \


### PR DESCRIPTION
Closes #2644. Can be obviated by https://github.com/nipreps-containers/miniconda/pull/2.