### PR TITLE
MNT: Ask for fmriprep-docker RUNNING line

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,9 @@ body:
     id: command
     attributes:
       label: What command did you use?
-      description: This helps us replicate the problem. This will be automatically formatted into code, so no need for backticks.
+      description: |
+        If you're using `fmriprep-docker`, please include the `RUNNING: ...` line that is printed first.
+        This helps us replicate the problem. This will be automatically formatted into code, so no need for backticks.
       render: shell
     validations:
       required: true


### PR DESCRIPTION
This will help distinguish between bugs in fMRIPrep and fmriprep-docker and also make it easier to ask diagnostic questions.