### PR TITLE
ENH: Allow `--use-syn-sdc` to take a "warn" option to avoid exiting when PE dir is unavailable

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -486,9 +486,13 @@ Useful for further Tedana processing post-fMRIPrep."""
     g_syn = parser.add_argument_group("Specific options for SyN distortion correction")
     g_syn.add_argument(
         "--use-syn-sdc",
-        action="store_true",
+        nargs="?",
+        choices=["warn", "error"],
+        action="store",
+        const="error",
         default=False,
-        help="EXPERIMENTAL: Use fieldmap-free distortion correction",
+        help="EXPERIMENTAL: Use fieldmap-free distortion correction; "
+             "if unable, error (default) or warn based on optional argument.",
     )
     g_syn.add_argument(
         "--force-syn",

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -333,7 +333,8 @@ It is released under the [CC0]\
                        "PhaseEncodingDirection information appears to be "
                        "absent.")
             config.loggers.workflow.error(message)
-            raise ValueError(message)
+            if config.workflow.use_syn_sdc == "error":
+                raise ValueError(message)
 
         if (
             "fieldmaps" in config.workflow.ignore


### PR DESCRIPTION
The main use case here is when writing a script to run fMRIPrep on heterogeneous datasets. This avoids having to pre-check each dataset/subject for whether `PhaseEncodingDirection` is available; you just run it if you can.

Also simplifies the (probably vanishingly rare) case where `PhaseEncodingDirection` may be available for some tasks/runs within a subject but not others.

The old behaviors are preserved, so this is bug-fix safe. `--use-syn-sdc` and `--use-syn-sdc error` are synonyms. `--use-syn-sdc warn` is the new feature.

Happy to consider alternative approaches, but I think this is useful functionality.