### PR TITLE
Revert "ENH: Allow `--use-syn-sdc` to take a "warn" option to avoid exiting when PE dir is unavailable"

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -486,13 +486,9 @@ Useful for further Tedana processing post-fMRIPrep."""
     g_syn = parser.add_argument_group("Specific options for SyN distortion correction")
     g_syn.add_argument(
         "--use-syn-sdc",
-        nargs="?",
-        choices=["warn", "error"],
-        action="store",
-        const="error",
+        action="store_true",
         default=False,
-        help="EXPERIMENTAL: Use fieldmap-free distortion correction; "
-             "if unable, error (default) or warn based on optional argument.",
+        help="EXPERIMENTAL: Use fieldmap-free distortion correction",
     )
     g_syn.add_argument(
         "--force-syn",

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -23,8 +23,6 @@
 """Test parser."""
 from packaging.version import Version
 from pkg_resources import resource_filename as pkgrf
-from argparse import ArgumentError
-from contextlib import nullcontext
 import pytest
 from ..parser import _build_parser, parse_args
 from .. import version as _version
@@ -194,32 +192,4 @@ def test_slice_time_ref(tmp_path, st_ref):
     parser = _build_parser()
 
     parser.parse_args(args)
-    _reset_config()
-
-
-@pytest.mark.parametrize("args, expectation", (
-    ([], False),
-    (["--use-syn-sdc"], "error"),
-    (["--use-syn-sdc", "error"], "error"),
-    (["--use-syn-sdc", "warn"], "warn"),
-    (["--use-syn-sdc", "other"], (SystemExit, ArgumentError)),
-))
-def test_use_syn_sdc(tmp_path, args, expectation):
-    bids_path = tmp_path / "data"
-    out_path = tmp_path / "out"
-    args = [str(bids_path), str(out_path), "participant"] + args
-    bids_path.mkdir()
-
-    parser = _build_parser()
-
-    cm = nullcontext()
-    if isinstance(expectation, tuple):
-        cm = pytest.raises(expectation)
-
-    with cm:
-        opts = parser.parse_args(args)
-
-    if not isinstance(expectation, tuple):
-        assert opts.use_syn_sdc == expectation
-
     _reset_config()

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -333,8 +333,7 @@ It is released under the [CC0]\
                        "PhaseEncodingDirection information appears to be "
                        "absent.")
             config.loggers.workflow.error(message)
-            if config.workflow.use_syn_sdc == "error":
-                raise ValueError(message)
+            raise ValueError(message)
 
         if (
             "fieldmaps" in config.workflow.ignore


### PR DESCRIPTION
Reverts nipreps/fmriprep#2680