### PR TITLE
MNT: Add netbase to Docker image to ensure correct datalad operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
                     autoconf \
                     libtool \
                     pkg-config \
+                    netbase \
                     git && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This creates the `/etc/protocols` file that allows Haskell (git-annex) to fetch web objects. Without it you can get responses like:

```
$ singularity exec code/containers/images/bids/bids-fmriprep--21.0.0.sing datalad get sourcedata/templateflow/tpl-OASIS30ANTs/tpl-OASIS30ANTs_res-01_T1w.nii.gz
get(error): sourcedata/templateflow/tpl-OASIS30ANTs/tpl-OASIS30ANTs_res-01_T1w.nii.gz (file) [https://files.osf.io/v1/resources/ue5gx/providers/osfstorage/5bc647b153cec4001aadab65 download failed: ConnectionFailure Network.BSD.getProtocolByName: does not exist (no such protocol name: tcp)
downloading from all 1 known url(s) failed
https://files.osf.io/v1/resources/ue5gx/providers/osfstorage/5bc647b153cec4001aadab65 download failed: ConnectionFailure Network.BSD.getProtocolByName: does not exist (no such protocol name: tcp)
downloading from all 1 known url(s) failed
https://files.osf.io/v1/resources/ue5gx/providers/osfstorage/5bc647b153cec4001aadab65 download failed: ConnectionFailure Network.BSD.getProtocolByName: does not exist (no such protocol name: tcp)
downloading from all 1 known url(s) failed]
action summary:
  get (error: 1, notneeded: 1)
```

Fix found on https://github.com/commercialhaskell/stack/issues/2372#issuecomment-234113085.