### PR TITLE
FIX: Pass boolean use_syn_sdc to find_estimators

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -324,7 +324,7 @@ It is released under the [CC0]\
         fmap_estimators = find_estimators(
             layout=config.execution.layout,
             subject=subject_id,
-            fmapless=config.workflow.use_syn_sdc,
+            fmapless=bool(config.workflow.use_syn_sdc),
             force_fmapless=config.workflow.force_syn,
         )
 


### PR DESCRIPTION
Alternative to #2681. I think the reason we were hitting this edge case is that there was a type change.