### PR TITLE
MNT: Silence warning from pybids; list packaging as dependency

### DIFF
--- a/fmriprep/__init__.py
+++ b/fmriprep/__init__.py
@@ -19,9 +19,11 @@ __all__ = [
 # Silence PyBIDS warning for extension entity behavior
 # Can be removed once minimum PyBIDS dependency hits 0.14
 try:
+    from packaging.version import Version
     import bids
-    bids.config.set_option('extension_initial_dot', True)
+    if Version(bids.__version__) < Version('0.14'):
+        bids.config.set_option('extension_initial_dot', True)
 except (ImportError, ValueError):
     pass
 else:
-    del bids
+    del Version, bids

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     nitransforms ~= 21.0.0
     niworkflows ~= 1.4.5
     numpy
+    packaging
     pandas
     psutil >= 5.4
     pybids >= 0.12.1
@@ -49,7 +50,6 @@ packages = find:
 [options.extras_require]
 datalad = datalad
 doc =
-    packaging
     pydot >= 1.2.3
     pydotplus
     sphinx >= 1.8


### PR DESCRIPTION
Lesson learned about trying to cycle through FutureWarnings/DeprecationWarnings to change APIs with no quiet period.

Also, we use `packaging` for more than just docs. Promoted to a first-class dependency.