### PR TITLE
FIX: Check for empty ACompCor results before trying to rename

### DIFF
--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -125,6 +125,15 @@ class RenameACompCor(SimpleInterface):
     output_spec = _RenameACompCorOutputSpec
 
     def _run_interface(self, runtime):
+        try:
+            components = pd.read_csv(self.inputs.components_file, sep='\t')
+            metadata = pd.read_csv(self.inputs.metadata_file, sep='\t')
+        except pd.errors.EmptyDataError:
+            # Can occur when testing on short datasets; otherwise rare
+            self._results["components_file"] = self.inputs.components_file
+            self._results["metadata_file"] = self.inputs.metadata_file
+            return runtime
+
         self._results["components_file"] = fname_presuffix(
             self.inputs.components_file,
             suffix='_renamed',
@@ -136,8 +145,6 @@ class RenameACompCor(SimpleInterface):
             use_ext=True,
             newpath=runtime.cwd)
 
-        components = pd.read_csv(self.inputs.components_file, sep='\t')
-        metadata = pd.read_csv(self.inputs.metadata_file, sep='\t')
         all_comp_cor = metadata[metadata["retained"]]
 
         c_comp_cor = all_comp_cor[all_comp_cor["mask"] == "CSF"]


### PR DESCRIPTION
## Changes proposed in this pull request

This only happens on ds210 during CI, as far as I can tell, because the time series is so short. If we detect empty files, just pass them along to the next node.

Closes #2659.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
