### PR TITLE
BF(DOC): use a BIDS compliant _mask instead of old BEP03 _roi to point to lesion mask

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -121,8 +121,8 @@ ANTs will use this mask to minimize warping of healthy tissue into damaged
 areas (or vice-versa).
 Lesion masks should be binary NIfTI images (damaged areas = 1, everywhere else = 0)
 in the same space and resolution as the T1 image, and follow the naming convention specified in
-`BIDS Extension Proposal 3: Common Derivatives <https://docs.google.com/document/d/1Wwc4A6Mow4ZPPszDIWfCUCRNstn7d_zzaWPcfcHmgI4/edit#heading=h.9146wuepclkt>`_
-(e.g., ``sub-001_T1w_label-lesion_roi.nii.gz``).
+`BIDS Masks <https://bids-specification.readthedocs.io/en/stable/05-derivatives/03-imaging.html#masks>`_
+(e.g. ``sub-001_space-orig_label-L_mask.nii.gz``).
 This file should be placed in the ``sub-*/anat`` directory of the BIDS dataset
 to be run through *fMRIPrep*.
 Because lesion masks are not currently part of the BIDS specification, it is also necessary to

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -125,13 +125,6 @@ in the same space and resolution as the T1 image, and follow the naming conventi
 (e.g. ``sub-001_space-orig_label-L_mask.nii.gz``).
 This file should be placed in the ``sub-*/anat`` directory of the BIDS dataset
 to be run through *fMRIPrep*.
-Because lesion masks are not currently part of the BIDS specification, it is also necessary to
-include a ``.bidsignore`` file in the root of your dataset directory. This will prevent
-`bids-validator <https://github.com/bids-standard/bids-validator#bidsignore>`_ from complaining
-that your dataset is not valid BIDS, which prevents *fMRIPrep* from running.
-Your ``.bidsignore`` file should include the following line::
-
-  *lesion_roi.nii.gz
 
 Longitudinal processing
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Not sure if the specific name is the best one, since does not point
explicitly to T1w as the orig of that mask, and either label should
may be made extended instead of abbreviated L.

But in either case, old doc example is clearly wrong thus this fix

Attn @michael-sun