### PR TITLE
FIX: Set pixdim[4] (repetition time) in seconds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     nilearn ~= 0.6.2
     nitime
     nitransforms >= 20.0.0rc3, < 20.2
-    niworkflows ~= 1.3.5
+    niworkflows ~= 1.3.6
     numpy
     pandas
     psutil >= 5.4


### PR DESCRIPTION
In cases when the input BOLD series has `pixdim[4]` in ms, we update the output series to have the temporal units of seconds, but do not set the `pixdim[4]` field to seconds. This release of niworkflows fixes that.

Low priority for release, IMO.