### PR TITLE
FIX: Initialize BIDS layout after cleaning working directory

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -672,11 +672,11 @@ def parse_args(args=None, namespace=None):
 
     if opts.config_file:
         skip = {} if opts.reports_only else {"execution": ("run_uuid",)}
-        config.load(opts.config_file, skip=skip)
+        config.load(opts.config_file, skip=skip, init=False)
         config.loggers.cli.info(f"Loaded previous configuration file {opts.config_file}")
 
     config.execution.log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
-    config.from_dict(vars(opts))
+    config.from_dict(vars(opts), init=['nipype'])
 
     if not config.execution.notrack:
         import pkgutil
@@ -762,6 +762,12 @@ applied."""
             build_log.warning(
                 f"Could not clear all contents of working directory: {work_dir}"
             )
+
+    # Update the config with an empty dict to trigger initialization of all config
+    # sections (we used `init=False` above).
+    # This must be done after cleaning the work directory, or we could delete an
+    # open SQLite database
+    config.from_dict({})
 
     # Ensure input and output folders are not the same
     if output_dir == bids_dir:


### PR DESCRIPTION
I saw three options.

1) Protect the PyBIDS DB from being deleted by `--clean-workdir`. This complicates the cleaning code.
2) Move cleaning into `config.execution.init`, which seems bad as I think initialization is supposed to be okay to do multiple times. Destructive filesystem operations certainly seem bad to hide in configuration init.
3) Have a separate explicit layout initialization step that we call after cleaning the work-dir.

Went for option 3.

Fixes #2721 