### PR TITLE
CI: Update package builds to use python -m build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1060,18 +1060,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update build tools
+          command: python -m pip install --user pip build twine
+      - run:
           name: Build fMRIPrep
-          command: |
-            python -m pip install --user twine  # For use in checking distributions
-            THISVERSION=$( python get_version.py )
-            THISVERSION=${THISVERSION%.dirty*}
-            THISVERSION=${CIRCLE_TAG:-$THISVERSION}
-            virtualenv --python=python build
-            source build/bin/activate
-            pip install --upgrade "pip>=19.1" numpy
-            echo "${CIRCLE_TAG:-$THISVERSION}" > fmriprep/VERSION
-            python setup.py sdist
-            python -m pip wheel --no-deps -w dist/ .
+          command: python -m build
       - store_artifacts:
           path: /tmp/src/fmriprep/dist
       - run:
@@ -1114,13 +1107,8 @@ jobs:
           command: |
             THISVERSION=$( python get_version.py )
             THISVERSION=${THISVERSION%.dirty*}
-            cd wrapper
-            virtualenv --python=python build
-            source build/bin/activate
-            python -m pip install --upgrade "pip>=19.1"
-            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" fmriprep_docker.py
-            python setup.py sdist
-            python -m pip wheel --no-deps -w dist/ .
+            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" wrapper/fmriprep_docker.py
+            python -m build wrapper/
       - store_artifacts:
           path: /tmp/src/fmriprep/wrapper/dist
 
@@ -1131,30 +1119,21 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update build tools
+          command: python -m pip install --user build twine
+      - run:
           name: Build fMRIPrep
-          command: |
-            THISVERSION=$( python get_version.py )
-            virtualenv --python=python build
-            source build/bin/activate
-            python -m pip install --upgrade "pip>=19.1"
-            echo "${CIRCLE_TAG:-$THISVERSION}" > fmriprep/VERSION
-            python setup.py sdist
-            python -m pip wheel --no-deps -w dist/ .
+          command: python -m build
       - run:
           name: Build fmriprep-docker
           command: |
             THISVERSION=$( python get_version.py )
-            cd wrapper
-            virtualenv --python=python build
-            source build/bin/activate
-            python -m pip install --upgrade "pip>=19.1"
-            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" fmriprep_docker.py
-            python setup.py sdist
-            python -m pip wheel --no-deps -w dist/ .
+            THISVERSION=${THISVERSION%.dirty*}
+            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" wrapper/fmriprep_docker.py
+            python -m build wrapper/
       - run:
           name: Upload packages to PyPI
           command: |
-            python -m pip install --user twine
             python -m twine upload dist/fmriprep* wrapper/dist/fmriprep*
 
   deployable:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1055,7 +1055,7 @@ jobs:
 
   test_deploy_pypi:
     docker:
-      - image: circleci/python:3.8.5
+      - image: cimg/python:3.9
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout
@@ -1114,7 +1114,7 @@ jobs:
 
   deploy_pypi:
     docker:
-      - image: circleci/python:3.8.5
+      - image: cimg/python:3.9
     working_directory: /tmp/src/fmriprep
     steps:
       - checkout

--- a/.maint/ci/build_archive.sh
+++ b/.maint/ci/build_archive.sh
@@ -11,21 +11,22 @@ echo "INSTALL_TYPE = $INSTALL_TYPE"
 
 set -x
 
-if [ "$INSTALL_TYPE" == "sdist" ]; then
-    python setup.py egg_info  # check egg_info while we're here
-    python setup.py sdist
-    export ARCHIVE=$( ls dist/*.tar.gz )
-elif [ "$INSTALL_TYPE" == "wheel" ]; then
-    python setup.py bdist_wheel
-    export ARCHIVE=$( ls dist/*.whl )
-elif [ "$INSTALL_TYPE" == "archive" ]; then
-    export ARCHIVE="package.tar.gz"
+if [ "$INSTALL_TYPE" = "sdist" -o "$INSTALL_TYPE" = "wheel" ]; then
+    python -m build
+elif [ "$INSTALL_TYPE" = "archive" ]; then
+    ARCHIVE="/tmp/package.tar.gz"
     git archive -o $ARCHIVE HEAD
-elif [ "$INSTALL_TYPE" == "pip" ]; then
-    export ARCHIVE="."
 fi
 
-if [ "${ARCHIVE:0:5}" = "dist/" ]; then
+if [ "$INSTALL_TYPE" = "sdist" ]; then
+    ARCHIVE=$( ls $PWD/dist/*.tar.gz )
+elif [ "$INSTALL_TYPE" = "wheel" ]; then
+    ARCHIVE=$( ls $PWD/dist/*.whl )
+elif [ "$INSTALL_TYPE" = "pip" ]; then
+    ARCHIVE="$PWD"
+fi
+
+if [ "$INSTALL_TYPE" = "sdist" -o "$INSTALL_TYPE" = "wheel" ]; then
     python -m pip install twine
     python -m twine check $ARCHIVE
 fi

--- a/.maint/ci/env.sh
+++ b/.maint/ci/env.sh
@@ -1,4 +1,4 @@
-SETUP_REQUIRES="pip setuptools>=40.8 wheel"
+SETUP_REQUIRES="pip build"
 
 # Numpy and scipy upload nightly/weekly/intermittent wheels
 NIGHTLY_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"


### PR DESCRIPTION
* ~~Run tests/doctests on Python 3.10 in GitHub Actions~~ No vtk for Python 3.10, so we can't install niworkflows.
* Build sdists/wheels with `python -m build`, which provides build isolation, so we don't need to use our own on CircleCI
* Remove the `VERSION` file from sdist/wheel builds. We check whether the packages have the correct version added by versioneer.