### PR TITLE
ENH: Save T2starmap files in all requested output spaces, if calculated

### DIFF
--- a/.circleci/ds210_fasttrack_outputs.txt
+++ b/.circleci/ds210_fasttrack_outputs.txt
@@ -29,5 +29,6 @@ fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-b
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_T2starmap.nii.gz
 fmriprep/sub-02.html
 /tmp/ds210/derivatives

--- a/.circleci/ds210_fasttrack_outputs.txt
+++ b/.circleci/ds210_fasttrack_outputs.txt
@@ -29,6 +29,7 @@ fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-b
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_T2starmap.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_T2starmap.nii.gz
 fmriprep/sub-02.html
 /tmp/ds210/derivatives

--- a/.circleci/ds210_outputs.txt
+++ b/.circleci/ds210_outputs.txt
@@ -48,6 +48,7 @@ fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-b
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_T2starmap.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_T2starmap.nii.gz
 fmriprep/sub-02.html
 /tmp/ds210/derivatives

--- a/.circleci/ds210_outputs.txt
+++ b/.circleci/ds210_outputs.txt
@@ -48,5 +48,6 @@ fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-b
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
 fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
+fmriprep/sub-02/func/sub-02_task-cuedSGT_run-01_space-MNI152NLin2009cAsym_T2starmap.nii.gz
 fmriprep/sub-02.html
 /tmp/ds210/derivatives

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -235,6 +235,38 @@ are saved::
       sub-<subject_label>_[specifiers]_AROMAnoiseICs.csv
       sub-<subject_label>_[specifiers]_desc-MELODIC_mixing.tsv
 
+**Multi-echo derivatives**.
+For multi-echo datasets, the output ``_bold`` series are "optimally combined" by
+`tedana`_ to better estimate the BOLD signal.
+This process also generates a T2\* map, which is resampled into every requested output
+space.
+
+::
+
+  sub-<subject_label>/
+    func/
+      sub-<subject_label>_[specifiers]_T2starmap.nii.gz
+
+If the ``--me-output-echos`` flag is specified, then the distortion-corrected (STC, HMC, SDC)
+per-echo time series are output. For example, if the inputs are of the form::
+
+  sub-01/
+    func/
+      sub-01_task-rest_echo-1_bold.nii.gz
+      sub-01_task-rest_echo-2_bold.nii.gz
+      sub-01_task-rest_echo-3_bold.nii.gz
+
+Then the output will include::
+
+  sub-01/
+    func/
+      sub-01_task-rest_echo-1_desc-preproc_bold.nii.gz
+      sub-01_task-rest_echo-2_desc-preproc_bold.nii.gz
+      sub-01_task-rest_echo-3_desc-preproc_bold.nii.gz
+
+These may then be used independently with multi-echo tools, such as `tedana`_,
+to perform more advanced denoising or alternative combination strategies.
+
 .. danger::
    Slice timing correction in *fMRIPrep* is referenced to the middle slice by default,
    which leads to a time shift in the volume onsets by 0.5 TR (repetition time).

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -748,6 +748,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             mem_gb=mem_gb["resampled"],
             omp_nthreads=omp_nthreads,
             spaces=spaces,
+            multiecho=multiecho,
             name="bold_std_trans_wf",
             use_compression=not config.execution.low_mem,
         )
@@ -764,6 +765,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ]),
             (bold_final, bold_std_trans_wf, [
                 ("mask", "inputnode.bold_mask"),
+                ("t2star", "inputnode.t2star"),
             ]),
             (bold_reg_wf, bold_std_trans_wf, [
                 ("outputnode.itk_bold_to_t1", "inputnode.itk_bold_to_t1"),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -119,24 +119,62 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
     -------
     bold_t1
         BOLD series, resampled to T1w space
+    bold_t1_ref
+        BOLD reference image, resampled to T1w space
+    bold2anat_xfm
+        Affine transform from BOLD reference space to T1w space
+    anat2bold_xfm
+        Affine transform from T1w space to BOLD reference space
     bold_mask_t1
         BOLD series mask in T1w space
+    bold_aseg_t1
+        FreeSurfer ``aseg`` resampled to match ``bold_t1``
+    bold_aparc_t1
+        FreeSurfer ``aparc+aseg`` resampled to match ``bold_t1``
     bold_std
         BOLD series, resampled to template space
+    bold_std_ref
+        BOLD reference image, resampled to template space
     bold_mask_std
         BOLD series mask in template space
-    confounds
-        TSV of confounds
+    bold_aseg_std
+        FreeSurfer ``aseg`` resampled to match ``bold_std``
+    bold_aparc_std
+        FreeSurfer ``aparc+aseg`` resampled to match ``bold_std``
+    bold_native
+        BOLD series, with distortion corrections applied (native space)
+    bold_native_ref
+        BOLD reference image in native space
+    bold_mask_native
+        BOLD series mask in native space
+    bold_echos_native
+        Per-echo BOLD series, with distortion corrections applied
+    bold_cifti
+        BOLD CIFTI image
+    cifti_variant
+        combination of target spaces for ``bold_cifti``
+    cifti_metadata
+        Path of metadata files corresponding to ``bold_cifti``.
+    cifti_density
+        Density (i.e., either ``91k`` or ``170k``) of ``bold_cifti``.
     surfaces
         BOLD series, resampled to FreeSurfer surfaces
+    t2star_bold
+        Estimated T2\\* map in BOLD native space
+    t2star_t1
+        Estimated T2\\* map in T1w space
+    t2star_std
+        Estimated T2\\* map in template space
+    confounds
+        TSV of confounds
     aroma_noise_ics
         Noise components identified by ICA-AROMA
     melodic_mix
         FSL MELODIC mixing matrix
-    bold_cifti
-        BOLD CIFTI image
-    cifti_variant
-        combination of target spaces for `bold_cifti`
+    nonaggr_denoised_file
+        BOLD series, in native space, with non-agressive AROMA denoising applied
+    confounds_metadata
+        Confounds metadata dictionary
 
     See Also
     --------

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -169,6 +169,11 @@ def init_func_derivatives_wf(
     # BOLD series will generally be unmasked unless multiecho,
     # as the optimal combination is undefined outside a bounded mask
     masked = multiecho
+    t2star_meta = {
+        'Units': 's',
+        'EstimationReference': 'doi:10.1002/mrm.20900',
+        'EstimationAlgorithm': 'monoexponential decay model',
+    }
 
     inputnode = pe.Node(niu.IdentityInterface(fields=[
         'aroma_noise_ics', 'bold_aparc_std', 'bold_aparc_t1', 'bold_aseg_std',
@@ -248,13 +253,15 @@ def init_func_derivatives_wf(
         if multiecho:
             ds_t2star_bold = pe.Node(
                 DerivativesDataSink(base_directory=output_dir, space='boldref',
-                                    suffix='T2starmap', compress=True, dismiss_entities=("echo",)),
+                                    suffix='T2starmap', compress=True, dismiss_entities=("echo",),
+                                    **t2star_meta),
                 name='ds_t2star_bold', run_without_submitting=True,
                 mem_gb=DEFAULT_MEMORY_MIN_GB)
 
             workflow.connect([
                 (inputnode, ds_t2star_bold, [('source_file', 'source_file'),
                                              ('t2star_bold', 'in_file')]),
+                (raw_sources, ds_t2star_bold, [('out', 'RawSources')]),
             ])
 
     if multiecho and config.execution.me_output_echos:
@@ -322,13 +329,15 @@ def init_func_derivatives_wf(
         if multiecho:
             ds_t2star_t1 = pe.Node(
                 DerivativesDataSink(base_directory=output_dir, space='T1w',
-                                    suffix='T2starmap', compress=True, dismiss_entities=("echo",)),
+                                    suffix='T2starmap', compress=True, dismiss_entities=("echo",),
+                                    **t2star_meta),
                 name='ds_t2star_t1', run_without_submitting=True,
                 mem_gb=DEFAULT_MEMORY_MIN_GB)
 
             workflow.connect([
                 (inputnode, ds_t2star_t1, [('source_file', 'source_file'),
                                            ('t2star_t1', 'in_file')]),
+                (raw_sources, ds_t2star_t1, [('out', 'RawSources')]),
             ])
 
     if use_aroma:
@@ -457,7 +466,8 @@ def init_func_derivatives_wf(
         if multiecho:
             ds_t2star_std = pe.Node(
                 DerivativesDataSink(base_directory=output_dir, suffix='T2starmap',
-                                    compress=True, dismiss_entities=("echo",)),
+                                    compress=True, dismiss_entities=("echo",),
+                                    **t2star_meta),
                 name='ds_t2star_std', run_without_submitting=True,
                 mem_gb=DEFAULT_MEMORY_MIN_GB)
 
@@ -468,6 +478,7 @@ def init_func_derivatives_wf(
                                               ('cohort', 'cohort'),
                                               ('resolution', 'resolution'),
                                               ('density', 'density')]),
+                (raw_sources, ds_t2star_std, [('out', 'RawSources')]),
             ])
 
     fs_outputs = spaces.cached.get_fs_spaces()

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -277,6 +277,8 @@ def init_bold_std_trans_wf(
         Skull-stripping mask of reference image
     bold_split
         Individual 3D volumes, not motion corrected
+    t2star
+        Estimated T2\\* map in BOLD native space
     fieldwarp
         a :abbr:`DFM (displacements field map)` in ITK format
     hmc_xforms
@@ -304,6 +306,8 @@ def init_bold_std_trans_wf(
     bold_aparc_std
         FreeSurfer's ``aparc+aseg.mgz`` atlas, in template space at the BOLD resolution
         (only if ``recon-all`` was run)
+    t2star_std
+        Estimated T2\\* map in template space
     template
         Template identifiers synchronized correspondingly to previously
         described outputs.


### PR DESCRIPTION
## Changes proposed in this pull request

Resample T2* map (calculated in BOLD space) to T1w and standard spaces if requested. Sink any of these as functional derivatives.

Unclear what would happen with fsaverage, so will need to test this case.

## Documentation that should be reviewed

Need to update expected outputs.
