### PR TITLE
ENH: Plot histogram of T2* values in gray-matter mask

### DIFF
--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -103,6 +103,10 @@ sections:
       of the T2\* map and the BOLD reference map used for BOLD-T1w coregistration.
     static: false
     subtitle: T2\* map
+  - bids: {datatype: figures, desc: t2starhist, suffix: bold}
+    caption: A histogram of estimated T2\* values within the anatomically-derived gray-matter mask.
+    static: false
+    subtitle: T2\* gray-matter values
   - bids: {datatype: figures, desc: flirtnobbr, suffix: bold}
     caption: <code>mri_coreg</code> (FreeSurfer) was used to generate transformations
       from EPI space to T1 Space - BBR refinement using FSL <code>flirt</code> rejected.

--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -101,10 +101,12 @@ sections:
   - bids: {datatype: figures, desc: t2scomp, suffix: bold}
     caption: A T2* map was calculated from the echos. Here, we show the comparison
       of the T2* map and the BOLD reference map used for BOLD-T1w coregistration.
+      The red contour shows the anatomical gray-matter mask resampled into BOLD space.
     static: false
     subtitle: T2* map
   - bids: {datatype: figures, desc: t2starhist, suffix: bold}
-    caption: A histogram of estimated T2* values within the anatomically-derived gray-matter mask.
+    caption: A histogram of estimated T2* values within the anatomically-derived gray-matter mask
+      shown in the previous plot.
     static: false
     subtitle: T2* gray-matter values
   - bids: {datatype: figures, desc: flirtnobbr, suffix: bold}

--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -99,14 +99,14 @@ sections:
     static: false
     subtitle: Experimental fieldmap-less susceptibility distortion correction
   - bids: {datatype: figures, desc: t2scomp, suffix: bold}
-    caption: A T2\* map was calculated from the echos. Here, we show the comparison
-      of the T2\* map and the BOLD reference map used for BOLD-T1w coregistration.
+    caption: A T2* map was calculated from the echos. Here, we show the comparison
+      of the T2* map and the BOLD reference map used for BOLD-T1w coregistration.
     static: false
-    subtitle: T2\* map
+    subtitle: T2* map
   - bids: {datatype: figures, desc: t2starhist, suffix: bold}
-    caption: A histogram of estimated T2\* values within the anatomically-derived gray-matter mask.
+    caption: A histogram of estimated T2* values within the anatomically-derived gray-matter mask.
     static: false
-    subtitle: T2\* gray-matter values
+    subtitle: T2* gray-matter values
   - bids: {datatype: figures, desc: flirtnobbr, suffix: bold}
     caption: <code>mri_coreg</code> (FreeSurfer) was used to generate transformations
       from EPI space to T1 Space - BBR refinement using FSL <code>flirt</code> rejected.

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -32,6 +32,7 @@ from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec,
     File, Directory, InputMultiObject, Str, isdefined,
     SimpleInterface)
+from niworkflows.interfaces.reportlets import base as nrb
 from smriprep.interfaces.freesurfer import ReconAll
 
 
@@ -272,6 +273,56 @@ class AboutSummary(SummaryInterface):
         return ABOUT_TEMPLATE.format(version=self.inputs.version,
                                      command=self.inputs.command,
                                      date=time.strftime("%Y-%m-%d %H:%M:%S %z"))
+
+
+class LabeledHistogramInputSpec(nrb._SVGReportCapableInputSpec):
+    in_file = traits.File(
+        exists=True,
+        mandatory=True,
+        desc="Image containing values to plot"
+    )
+    label_file = traits.File(
+        exists=True,
+        desc="Mask or label image where non-zero values will be used to extract data from in_file"
+    )
+    mapping = traits.Dict(desc="Map integer label values onto names of voxels")
+    xlabel = traits.Str("voxels", usedefault=True, desc="Description of values plotted")
+
+
+class LabeledHistogram(nrb.ReportingInterface):
+    input_spec = LabeledHistogramInputSpec
+
+    def _generate_report(self):
+        import numpy as np
+        import nibabel as nb
+        from nilearn.image import resample_to_img
+        from matplotlib import pyplot as plt
+        import seaborn as sns
+
+        report_file = self._out_report
+        img = nb.load(self.inputs.in_file)
+        data = img.get_fdata(dtype=np.float32)
+
+        if self.inputs.label_file:
+            label_img = nb.load(self.inputs.label_file)
+            if label_img.shape != img.shape[:3] or not np.allclose(label_img.affine, img.affine):
+                label_img = resample_to_img(label_img, img, interpolation="nearest")
+            labels = np.uint16(label_img.dataobj)
+        else:
+            labels = np.uint8(data > 0)
+
+        uniq_labels = np.unique(labels[labels > 0])
+        label_map = self.inputs.mapping or {label: label for label in uniq_labels}
+
+        rois = {
+            label_map.get(label, label): data[labels == label]
+            for label in label_map
+        }
+        with sns.axes_style('whitegrid'):
+            fig = sns.histplot(rois, bins=50)
+            fig.set_xlabel(self.inputs.xlabel)
+        plt.savefig(report_file)
+        plt.close()
 
 
 def get_world_pedir(ornt, pe_direction):

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -94,7 +94,7 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
     t1w_dseg
         Segmentation of preprocessed structural image, including
         gray-matter (GM), white-matter (WM) and cerebrospinal fluid (CSF)
-    t1w_asec
+    t1w_aseg
         Segmentation of structural image, done with FreeSurfer.
     t1w_aparc
         Parcellation of structural image, done with FreeSurfer.


### PR DESCRIPTION
## Changes proposed in this pull request

Closes #2541. I think we should also show the gray-matter mask in the T2*-boldref map immediately above the histogram.

## Documentation that should be reviewed

Working on the OHBM poster should provide some images/text that can be added to the docs.