### PR TITLE
FIX: Re-add missing `getfullpath` FreeSurfer binary

### DIFF
--- a/docker/files/freesurfer7.2-exclude.txt
+++ b/docker/files/freesurfer7.2-exclude.txt
@@ -200,7 +200,6 @@ freesurfer/bin/gcatrainskull
 freesurfer/bin/gdcmconv.fs
 freesurfer/bin/gems_compute_binary_atlas_probs
 freesurfer/bin/get_label_thickness
-freesurfer/bin/getfullpath
 freesurfer/bin/grad_unwarp
 freesurfer/bin/groupstats
 freesurfer/bin/groupstatsdiff


### PR DESCRIPTION
As noted in https://github.com/nipreps/smriprep/issues/286, `getfullpath` may be called by RCA