### PR TITLE
FIX: Filter sbrefs by BIDS filters if available

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -231,12 +231,14 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
     )
 
     # Find associated sbref, if possible
-    entities = (
-        config.execution.bids_filters.get('sbref', {}) if config.execution.bids_filters else {}
-    )
-    entities["suffix"] = "sbref"
-    entities["extension"] = [".nii", ".nii.gz"]  # Overwrite extensions
-    sbref_files = layout.get(return_type="file", **entities)
+    overrides = {
+        "suffix": "sbref",
+        "extension": [".nii", ".nii.gz"],
+    }
+    if config.execution.bids_filters:
+        overrides.update(config.execution.bids_filters.get('sbref', {}))
+    sb_ents = {**entities, **overrides}
+    sbref_files = layout.get(return_type="file", **sb_ents)
 
     sbref_msg = f"No single-band-reference found for {os.path.basename(ref_file)}."
     if sbref_files and "sbref" in config.workflow.ignore:

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -231,6 +231,9 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
     )
 
     # Find associated sbref, if possible
+    entities = (
+        config.execution.bids_filters.get('sbref', {}) if config.execution.bids_filters else {}
+    )
     entities["suffix"] = "sbref"
     entities["extension"] = [".nii", ".nii.gz"]  # Overwrite extensions
     sbref_files = layout.get(return_type="file", **entities)


### PR DESCRIPTION
Fixes #2839

I'm considering whether its cleaner to add `sbrefs` as a parameter to the workflow (function signature changing, so in a future minor bump) since we already have a data collection step https://github.com/nipreps/fmriprep/blob/c9c43ba5470c18bbfaf1cefb8800e2b377eeb405/fmriprep/workflows/base.py#L153-L158