### PR TITLE
ENH: Add check to ensure latest fsaverage folder is used

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -79,7 +79,9 @@ def init_fmriprep_wf():
             BIDSFreeSurferDir(
                 derivatives=config.execution.output_dir,
                 freesurfer_home=os.getenv('FREESURFER_HOME'),
-                spaces=config.workflow.spaces.get_fs_spaces()),
+                spaces=config.workflow.spaces.get_fs_spaces(),
+                minimum_fs_version="7.0.0",
+            ),
             name='fsdir_run_%s' % config.execution.run_uuid.replace('-', '_'),
             run_without_submitting=True)
         if config.execution.fs_subjects_dir is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,17 +24,17 @@ url = https://github.com/nipreps/fmriprep
 python_requires = >=3.7
 install_requires =
     nibabel >= 4.0.1
-    nipype >= 1.8.3
+    nipype >= 1.8.4
     nitime
     nitransforms >= 21.0.0
-    niworkflows ~= 1.6.2
+    niworkflows ~= 1.6.3
     numpy
     packaging
     pandas
     psutil >= 5.4
     pybids >= 0.15.0
     requests
-    sdcflows ~= 2.1.0
+    sdcflows ~= 2.1.1
     smriprep ~= 0.9.2
     tedana ~= 0.0.9
     templateflow >= 0.6


### PR DESCRIPTION
Closes #2832 

This sets a `minimum_fs_version` to ensure an FS7 recon-all compatible `fsaverage` is available.
Also bumps nipreps dependencies to the latest compatible versions.