### PR TITLE
FIX: Check for empty ACompCor results before trying to rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -745,7 +745,8 @@ jobs:
             set -x
             sudo mv /tmp/${DATASET}/derivatives/fmriprep/sub-100185.html \
                     /tmp/${DATASET}/derivatives/fmriprep/sub-100185_noerror.html
-            UUID=$(grep uuid /tmp/${DATASET}/work/*/config.toml | cut -d\" -f 2)
+            UUID=$(grep uuid /tmp/${DATASET}/work/*/config.toml | cut -d\" -f 2 | tail -n 1)
+            mkdir -p /tmp/${DATASET}/derivatives/fmriprep/sub-100185/log/$UUID/
             cp /tmp/src/fmriprep/fmriprep/data/tests/crash_files/*.txt \
                 /tmp/${DATASET}/derivatives/fmriprep/sub-100185/log/$UUID/
             set +e

--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -125,6 +125,15 @@ class RenameACompCor(SimpleInterface):
     output_spec = _RenameACompCorOutputSpec
 
     def _run_interface(self, runtime):
+        try:
+            components = pd.read_csv(self.inputs.components_file, sep='\t')
+            metadata = pd.read_csv(self.inputs.metadata_file, sep='\t')
+        except pd.errors.EmptyDataError:
+            # Can occur when testing on short datasets; otherwise rare
+            self._results["components_file"] = self.inputs.components_file
+            self._results["metadata_file"] = self.inputs.metadata_file
+            return runtime
+
         self._results["components_file"] = fname_presuffix(
             self.inputs.components_file,
             suffix='_renamed',
@@ -136,8 +145,6 @@ class RenameACompCor(SimpleInterface):
             use_ext=True,
             newpath=runtime.cwd)
 
-        components = pd.read_csv(self.inputs.components_file, sep='\t')
-        metadata = pd.read_csv(self.inputs.metadata_file, sep='\t')
         all_comp_cor = metadata[metadata["retained"]]
 
         c_comp_cor = all_comp_cor[all_comp_cor["mask"] == "CSF"]

--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -351,7 +351,11 @@ def _gather_confounds(signals=None, dvars=None, std_dvars=None, fdisp=None,
 
     confounds_data = pd.DataFrame()
     for file_name in all_files:  # assumes they all have headings already
-        new = pd.read_csv(file_name, sep="\t")
+        try:
+            new = pd.read_csv(file_name, sep="\t")
+        except pd.errors.EmptyDataError:
+            # No data, nothing to concat
+            continue
         for column_name in new.columns:
             new.rename(columns={column_name: camel_to_snake(less_breakable(column_name))},
                        inplace=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     nipype >= 1.5.1
     nitime
     nitransforms ~= 21.0.0
-    niworkflows ~= 1.4.9
+    niworkflows ~= 1.4.10
     numpy
     packaging
     pandas


### PR DESCRIPTION
## Changes proposed in this pull request

When running full fMRIPrep on test data, we can get empty compcor results. Since there's nothing to rename, this just passes empty files without attempting to modify them.

