### PR TITLE
RF: CIFTI generation

### DIFF
--- a/.circleci/ds005_legacy_partial_fasttrack_outputs.txt
+++ b/.circleci/ds005_legacy_partial_fasttrack_outputs.txt
@@ -32,7 +32,6 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsaverage5
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsaverage5_bold.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsnative_bold.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsnative_bold.json
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.dtseries.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.dtseries.nii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin2009cAsym_boldref.nii.gz

--- a/.circleci/ds005_legacy_partial_outputs.txt
+++ b/.circleci/ds005_legacy_partial_outputs.txt
@@ -73,7 +73,6 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsaverage5
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsaverage5_bold.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsnative_bold.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_hemi-R_space-fsnative_bold.json
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.dtseries.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.dtseries.nii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin2009cAsym_boldref.nii.gz

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -512,11 +512,6 @@ Setting-up fieldmap "{estimator.bids_id}" ({estimator.method}) with \
                 wf_inputs = getattr(fmap_wf.inputs, f"in_{estimator.bids_id}")
                 wf_inputs.in_data = [str(s.path) for s in estimator.sources]
                 wf_inputs.metadata = [s.metadata for s in estimator.sources]
-
-                # 21.0.x hack to change the number of volumes used
-                # The default of 50 takes excessively long
-                flatten = fmap_wf.get_node(f"wf_{estimator.bids_id}.flatten")
-                flatten.inputs.max_trs = config.workflow.topup_max_vols
             else:
                 raise NotImplementedError("Sophisticated PEPOLAR schemes are unsupported.")
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -973,7 +973,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
             # fmt:off
             workflow.connect([
-                (inputnode, bold_grayords_wf, [("subjects_dir", "inputnode.subjects_dir")]),
                 (bold_std_trans_wf, bold_grayords_wf, [
                     ("outputnode.bold_std", "inputnode.bold_std"),
                     ("outputnode.spatial_reference", "inputnode.spatial_reference"),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -151,8 +151,6 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
         BOLD CIFTI image
     cifti_metadata
         Path of metadata files corresponding to ``bold_cifti``.
-    cifti_density
-        Density (i.e., either ``91k`` or ``170k``) of ``bold_cifti``.
     surfaces
         BOLD series, resampled to FreeSurfer surfaces
     t2star_bold
@@ -384,7 +382,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 "bold_echos_native",
                 "bold_cifti",
                 "cifti_metadata",
-                "cifti_density",
                 "surfaces",
                 "t2star_bold",
                 "t2star_t1",
@@ -445,8 +442,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         use_aroma=config.workflow.use_aroma,
     )
     func_derivatives_wf.inputs.inputnode.all_source_files = bold_file
-    if config.workflow.cifti_output:
-        func_derivatives_wf.inputs.inputnode.cifti_density = config.workflow.cifti_output
+    func_derivatives_wf.inputs.inputnode.cifti_density = config.workflow.cifti_output
 
     # fmt:off
     workflow.connect([
@@ -470,7 +466,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ("nonaggr_denoised_file", "inputnode.nonaggr_denoised_file"),
             ("bold_cifti", "inputnode.bold_cifti"),
             ("cifti_metadata", "inputnode.cifti_metadata"),
-            ("cifti_density", "inputnode.cifti_density"),
             ("t2star_bold", "inputnode.t2star_bold"),
             ("t2star_t1", "inputnode.t2star_t1"),
             ("t2star_std", "inputnode.t2star_std"),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -149,8 +149,6 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
         Per-echo BOLD series, with distortion corrections applied
     bold_cifti
         BOLD CIFTI image
-    cifti_variant
-        combination of target spaces for ``bold_cifti``
     cifti_metadata
         Path of metadata files corresponding to ``bold_cifti``.
     cifti_density
@@ -385,7 +383,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 "bold_mask_native",
                 "bold_echos_native",
                 "bold_cifti",
-                "cifti_variant",
                 "cifti_metadata",
                 "cifti_density",
                 "surfaces",
@@ -448,6 +445,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         use_aroma=config.workflow.use_aroma,
     )
     func_derivatives_wf.inputs.inputnode.all_source_files = bold_file
+    if config.workflow.cifti_output:
+        func_derivatives_wf.inputs.inputnode.cifti_density = config.workflow.cifti_output
 
     # fmt:off
     workflow.connect([
@@ -470,7 +469,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ("melodic_mix", "inputnode.melodic_mix"),
             ("nonaggr_denoised_file", "inputnode.nonaggr_denoised_file"),
             ("bold_cifti", "inputnode.bold_cifti"),
-            ("cifti_variant", "inputnode.cifti_variant"),
             ("cifti_metadata", "inputnode.cifti_metadata"),
             ("cifti_density", "inputnode.cifti_density"),
             ("t2star_bold", "inputnode.t2star_bold"),
@@ -986,9 +984,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ]),
                 (bold_grayords_wf, outputnode, [
                     ("outputnode.cifti_bold", "bold_cifti"),
-                    ("outputnode.cifti_variant", "cifti_variant"),
                     ("outputnode.cifti_metadata", "cifti_metadata"),
-                    ("outputnode.cifti_density", "cifti_density"),
                 ]),
             ])
             # fmt:on
@@ -1009,12 +1005,11 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         )
 
         if config.workflow.cifti_output:
+            # fmt:off
             workflow.connect(
-                bold_grayords_wf,
-                "outputnode.cifti_bold",
-                carpetplot_wf,
-                "inputnode.cifti_bold",
+                bold_grayords_wf, "outputnode.cifti_bold", carpetplot_wf, "inputnode.cifti_bold",
             )
+            # fmt:on
 
         # fmt:off
         workflow.connect([

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -778,6 +778,7 @@ def init_func_derivatives_wf(
                 suffix='bold',
                 compress=False,
                 TaskName=metadata.get('TaskName'),
+                space='fsLR',
                 **timing_parameters,
             ),
             name='ds_bold_cifti',
@@ -788,7 +789,6 @@ def init_func_derivatives_wf(
         workflow.connect([
             (inputnode, ds_bold_cifti, [(('bold_cifti', _unlist), 'in_file'),
                                         ('source_file', 'source_file'),
-                                        (('cifti_metadata', _get_surface), 'space'),
                                         ('cifti_density', 'density'),
                                         (('cifti_metadata', _read_json), 'meta_dict')])
         ])
@@ -904,13 +904,6 @@ def _unlist(in_file):
     while isinstance(in_file, (list, tuple)) and len(in_file) == 1:
         in_file = in_file[0]
     return in_file
-
-
-def _get_surface(in_file):
-    from json import loads
-    from pathlib import Path
-
-    return loads(Path(in_file).read_text())["surface"]
 
 
 def _read_json(in_file):

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -202,7 +202,6 @@ def init_func_derivatives_wf(
                 'bold_native_ref',
                 'bold_mask_native',
                 'bold_echos_native',
-                'cifti_variant',
                 'cifti_metadata',
                 'cifti_density',
                 'confounds',

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     nipype >= 1.8.5
     nitime
     nitransforms >= 21.0.0
-    niworkflows ~= 1.6.4
+    niworkflows @ git+https://github.com/nipreps/niworkflows.git@master
     numpy
     packaging
     pandas


### PR DESCRIPTION
This cleans up a lot of the legacy code previously used to generate frankenstein MNI152NLin2009cAsym/fsaverage CIFTI-2 files.

- Removes legacy MNI152NLin2009cAsym/fsaverge hybrid space
- Remove redundant outputs (cifti variant/cifti density)

Follows work in https://github.com/nipreps/niworkflows/pull/756