### PR TITLE
ENH: Tag memory based on data shape, annotate T2SMap

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -564,7 +564,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         # create optimal combination, adaptive T2* map
         bold_t2s_wf = init_bold_t2s_wf(
             echo_times=tes,
-            mem_gb=mem_gb["resampled"],
+            mem_gb=mem_gb["filesize"],
             omp_nthreads=omp_nthreads,
             name="bold_t2smap_wf",
         )

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -31,6 +31,7 @@ Orchestrating the BOLD-preprocessing workflow
 import os
 
 import nibabel as nb
+import numpy as np
 from nipype.interfaces import utility as niu
 from nipype.interfaces.fsl import Split as FSLSplit
 from nipype.pipeline import engine as pe
@@ -1320,8 +1321,11 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
 
 def _create_mem_gb(bold_fname):
-    bold_size_gb = os.path.getsize(bold_fname) / (1024**3)
-    bold_tlen = nb.load(bold_fname).shape[-1]
+    img = nb.load(bold_fname)
+    nvox = int(np.prod(img.shape, dtype='u8'))
+    # Assume tools will coerce to 8-byte floats to be safe
+    bold_size_gb = 8 * nvox / (1024**3)
+    bold_tlen = img.shape[-1]
     mem_gb = {
         "filesize": bold_size_gb,
         "resampled": bold_size_gb * 4,

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -98,7 +98,11 @@ The optimally combined time series was carried forward as the *preprocessed BOLD
 
     LOGGER.log(25, 'Generating T2* map and optimally combined ME-EPI time series.')
 
-    t2smap_node = pe.Node(T2SMap(echo_times=list(echo_times)), name='t2smap_node')
+    t2smap_node = pe.Node(
+        T2SMap(echo_times=list(echo_times)),
+        name='t2smap_node',
+        mem_gb=2 * mem_gb * len(echo_times),
+    )
     # fmt:off
     workflow.connect([
         (inputnode, t2smap_node, [('bold_file', 'in_files'),

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -101,7 +101,7 @@ The optimally combined time series was carried forward as the *preprocessed BOLD
     t2smap_node = pe.Node(
         T2SMap(echo_times=list(echo_times)),
         name='t2smap_node',
-        mem_gb=2 * mem_gb * len(echo_times),
+        mem_gb=2.5 * mem_gb * len(echo_times),
     )
     # fmt:off
     workflow.connect([


### PR DESCRIPTION
## Changes proposed in this pull request

T2SMap was tagged with the default memory consumption (~100MB), when it should be based on the size of the input files. This implements #1100 in order to get a direct estimate of that, and then passes that along, with an additional factor based on the number of echos and a safety factor of 2.

Fixes #1100.
Fixes #2728.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
