### PR TITLE
FIX: Conform --reports-only to match post-run report generation

### DIFF
--- a/fmriprep/cli/workflow.py
+++ b/fmriprep/cli/workflow.py
@@ -36,10 +36,11 @@ def build_workflow(config_file, retval):
     """Create the Nipype Workflow that supports the whole execution graph."""
     from pathlib import Path
 
-    from niworkflows.reports import generate_reports
     from niworkflows.utils.bids import check_pipeline_version, collect_participants
     from niworkflows.utils.misc import check_valid_fs_license
     from pkg_resources import resource_filename as pkgrf
+
+    from fmriprep.reports.core import generate_reports
 
     from .. import config
     from ..utils.misc import check_deps
@@ -86,8 +87,8 @@ def build_workflow(config_file, retval):
     if config.execution.reports_only:
         build_log.log(25, "Running --reports-only on participants %s", ", ".join(subject_list))
         retval["return_code"] = generate_reports(
-            subject_list,
-            fmriprep_dir,
+            config.execution.participant_label,
+            config.execution.fmriprep_dir,
             config.execution.run_uuid,
             config=pkgrf("fmriprep", "data/reports-spec.yml"),
             packagename="fmriprep",


### PR DESCRIPTION
## Changes proposed in this pull request

Running `--reports-only` in `--output-layout bids` (now default) results in:

```console
221202-17:24:56,169 nipype.workflow IMPORTANT:
         Running --reports-only on participants 01
Process Process-2:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/opt/conda/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/conda/lib/python3.9/site-packages/fmriprep/cli/workflow.py", line 91, in build_workflow
    retval["return_code"] = generate_reports(
  File "/opt/conda/lib/python3.9/site-packages/niworkflows/reports/core.py", line 544, in generate_reports
    report_errors = [
  File "/opt/conda/lib/python3.9/site-packages/niworkflows/reports/core.py", line 545, in <listcomp>
    run_reports(
  File "/opt/conda/lib/python3.9/site-packages/niworkflows/reports/core.py", line 527, in run_reports
    return Report(
  File "/opt/conda/lib/python3.9/site-packages/niworkflows/reports/core.py", line 291, in __init__
    self._load_config(Path(config or pkgrf("niworkflows", "reports/default.yml")))
  File "/opt/conda/lib/python3.9/site-packages/niworkflows/reports/core.py", line 310, in _load_config
    self.index(settings["sections"])
  File "/opt/conda/lib/python3.9/site-packages/niworkflows/reports/core.py", line 322, in index
    self.init_layout()
  File "/opt/conda/lib/python3.9/site-packages/niworkflows/reports/core.py", line 313, in init_layout
    self.layout = BIDSLayout(self.root, config="figures", validate=False)
  File "/opt/conda/lib/python3.9/site-packages/bids/layout/layout.py", line 127, in __init__
    root, description = validate_root(root, validate)
  File "/opt/conda/lib/python3.9/site-packages/bids/layout/validation.py", line 68, in validate_root
    raise ValueError("BIDS root does not exist: %s" % root)
ValueError: BIDS root does not exist: /out/fmriprep/sub-01
```

This conforms to the usage in `cli/run.py`.


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
