### PR TITLE
REL: 22.1.0

### DIFF
--- a/.maint/update_changes.sh
+++ b/.maint/update_changes.sh
@@ -26,9 +26,22 @@ echo $( printf "%${#HEADER}s" | tr " " "=" ) >> newchanges
 echo "" >> newchanges
 
 # Search for PRs since previous release
-git log --grep="Merge pull request" `git describe --tags --abbrev=0`..HEAD --pretty='format:  * %b %s' | sed  's/Merge pull request \#\([^\d]*\)\ from\ .*/(\#\1)/' >> newchanges
-echo "" >> newchanges
-echo "" >> newchanges
+MERGE_COMMITS=$( git log --grep="Merge pull request\|(#.*)$" `git describe --tags --abbrev=0`..HEAD --pretty='format:%h' )
+for COMMIT in ${MERGE_COMMITS//\n}; do
+    SUB=$( git log -n 1 --pretty="format:%s" $COMMIT )
+    if ( echo $SUB | grep "^Merge pull request" ); then
+        # Merge commit
+        PR=$( echo $SUB | sed -e "s/Merge pull request \#\([0-9]*\).*/\1/" )
+        TITLE=$( git log -n 1 --pretty="format:%b" $COMMIT )
+    else
+        # Squashed merge
+        PR=$( echo $SUB | sed -e "s/.*(\#\([0-9]*\))$/\1/" )
+        TITLE=$( echo $SUB | sed -e "s/\(.*\) (\#[0-9]*)$/\1/" )
+    fi
+    echo "  * $TITLE (#$PR)" >> newchanges
+done
+echo >> newchanges
+echo >> newchanges
 
 # Add back the Upcoming header if it was present
 if [[ "$UPCOMING" == "0" ]]; then

--- a/.maint/update_zenodo.py
+++ b/.maint/update_zenodo.py
@@ -120,4 +120,4 @@ if __name__ == '__main__':
         if isinstance(creator['affiliation'], list):
             creator['affiliation'] = creator['affiliation'][0]
 
-    zenodo_file.write_text('%s\n' % json.dumps(zenodo, indent=2))
+    zenodo_file.write_text('%s\n' % json.dumps(zenodo, indent=2, ensure_ascii=False))

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,20 +4,14 @@
   "contributors": [
     {
       "affiliation": "Department of Radiology, Lausanne University Hospital and University of Lausanne",
-      "name": "Provins, C\u00e9line",
+      "name": "Provins, Céline",
       "orcid": "0000-0002-1668-9629",
       "type": "Researcher"
     },
     {
-      "affiliation": "Centre for Modern Interdisciplinary Technologies, Nicolaus Copernicus University in Toru\u0144",
+      "affiliation": "Centre for Modern Interdisciplinary Technologies, Nicolaus Copernicus University in Toruń",
       "name": "Finc, Karolina",
       "orcid": "0000-0002-0157-030X",
-      "type": "Researcher"
-    },
-    {
-      "affiliation": "University of Texas at Austin",
-      "name": "de la Vega, Alejandro",
-      "orcid": "0000-0001-9062-3778",
       "type": "Researcher"
     },
     {
@@ -27,21 +21,21 @@
       "type": "Researcher"
     },
     {
+      "affiliation": "Department of Neuroscience, University of Pennsylvania, PA, USA",
+      "name": "Tooley, Ursula A.",
+      "orcid": "0000-0001-6377-3885",
+      "type": "Researcher"
+    },
+    {
       "affiliation": "Department of Psychology, New York University",
       "name": "Benson, Noah C.",
       "orcid": "0000-0002-2365-8265",
       "type": "Researcher"
     },
     {
-      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
-      "name": "Waller, Lea",
-      "orcid": "0000-0002-3239-6957",
-      "type": "Researcher"
-    },
-    {
-      "affiliation": "Department of Neuroscience, University of Pennsylvania, PA, USA",
-      "name": "Tooley, Ursula A.",
-      "orcid": "0000-0001-6377-3885",
+      "affiliation": "University of Texas at Austin",
+      "name": "de la Vega, Alejandro",
+      "orcid": "0000-0001-9062-3778",
       "type": "Researcher"
     },
     {
@@ -54,6 +48,12 @@
       "affiliation": "Montreal Neurological Institute, McGill University",
       "name": "Urchs, Sebastian",
       "orcid": "0000-0001-5504-8579",
+      "type": "Researcher"
+    },
+    {
+      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
+      "name": "Waller, Lea",
+      "orcid": "0000-0002-3239-6957",
       "type": "Researcher"
     },
     {
@@ -81,12 +81,6 @@
       "type": "Researcher"
     },
     {
-      "affiliation": "Department of Radiology, Weill Cornell Medicine",
-      "name": "Jamison, Keith W.",
-      "orcid": "0000-0001-7139-6661",
-      "type": "Researcher"
-    },
-    {
       "affiliation": "McLean Hospital Brain Imaging Center, MA, USA",
       "name": "Frederick, Blaise B.",
       "orcid": "0000-0001-5832-5279",
@@ -99,9 +93,9 @@
       "type": "Researcher"
     },
     {
-      "affiliation": "CENIR, INSERM U1127, CNRS UMR 7225, UPMC Univ Paris 06 UMR S 1127, Institut du Cerveau et de la Moelle \u00e9pini\u00e8re, ICM, F-75013, Paris, France",
-      "name": "Valabregue, Romain",
-      "orcid": "0000-0002-1814-9570",
+      "affiliation": "Department of Radiology, Weill Cornell Medicine",
+      "name": "Jamison, Keith W.",
+      "orcid": "0000-0001-7139-6661",
       "type": "Researcher"
     },
     {
@@ -147,9 +141,15 @@
       "type": "Researcher"
     },
     {
-      "affiliation": "SIMEXP Lab, CRIUGM, University of Montr\u00e9al, Montr\u00e9al, Canada",
+      "affiliation": "SIMEXP Lab, CRIUGM, University of Montréal, Montréal, Canada",
       "name": "Bellec, Pierre",
       "orcid": "0000-0002-9111-0699",
+      "type": "Researcher"
+    },
+    {
+      "affiliation": "Montreal Neurological Institute, McGill University",
+      "name": "Bhagwat, Nikhil",
+      "orcid": "0000-0001-6073-7141",
       "type": "Researcher"
     },
     {
@@ -202,7 +202,7 @@
     },
     {
       "affiliation": "Cyceron, UMS 3408 (CNRS - UCBN), France",
-      "name": "Naveau, Mika\u00ebl",
+      "name": "Naveau, Mikaël",
       "orcid": "0000-0001-6948-9068",
       "type": "Researcher"
     },
@@ -226,7 +226,7 @@
     },
     {
       "affiliation": "Max Planck UCL Centre for Computational Psychiatry and Ageing Research, University College London",
-      "name": "Stoji\u0107, Hrvoje",
+      "name": "Stojić, Hrvoje",
       "orcid": "0000-0002-9699-9052",
       "type": "Researcher"
     },
@@ -234,6 +234,12 @@
       "affiliation": "Department of Psychology, Stanford University",
       "name": "Thompson, William H.",
       "orcid": "0000-0002-0533-6035",
+      "type": "Researcher"
+    },
+    {
+      "affiliation": "CENIR, INSERM U1127, CNRS UMR 7225, UPMC Univ Paris 06 UMR S 1127, Institut du Cerveau et de la Moelle épinière, ICM, F-75013, Paris, France",
+      "name": "Valabregue, Romain",
+      "orcid": "0000-0002-1814-9570",
       "type": "Researcher"
     },
     {
@@ -279,7 +285,7 @@
     },
     {
       "affiliation": "Lausanne University Hospital and University of Lausanne, Lausanne, Switzerland",
-      "name": "Provins, C\u00e9line",
+      "name": "Provins, Céline",
       "orcid": "0000-0002-1668-9629"
     },
     {
@@ -303,7 +309,7 @@
       "orcid": "0000-0001-6347-7939"
     },
     {
-      "affiliation": "SIMEXP Lab, CRIUGM, University of Montr\u00e9al, Montr\u00e9al, Canada",
+      "affiliation": "SIMEXP Lab, CRIUGM, University of Montréal, Montréal, Canada",
       "name": "Pinsard, Basile",
       "orcid": "0000-0002-4391-3075"
     },

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,59 @@
+22.1.0 (December 12, 2022)
+==========================
+New feature release in the 22.1.x series.
+
+This is an incremental improvement on the 22.0.x series, including features and fixes that
+are backwards incompatible with the 22.0.x work tree.
+
+Several significant issues with susceptibility distortion correction (SDC) have been fixed
+in `SDCFlows 2.2.0`_, in addition to the changes listed below.
+If you have been seeing issues with SDC in 21.0.x or 22.0.x, please test out this version
+and submit issues.
+
+Additionally, this version includes improvements to structural preprocessing, generating
+morphometric ``.shape.gii`` files from FreeSurfer derivatives.
+
+Finally, this release introduces a method for estimating the carbon footprint of using
+fMRIPrep. Add ``--track-carbon`` to your command to try this out. Note that it does not work
+in Docker containers, but should work for Singularity containers.
+
+With thanks to Nikhil Bhagwat for contributions.
+
+
+  * FIX: Conform --reports-only to match post-run report generation (#2900)
+  * FIX: Remove cortex masking during vol2surf sampling (#2879)
+  * FIX: Do not attempt to calculate TA if SliceTiming is degenerate (#2901)
+  * FIX: Pass CrownCompCor components to GatherConfounds (#2897)
+  * FIX: Output brain mask and boldref in BOLD space if individual echos requested (#2852)
+  * FIX: Check for empty ACompCor results before trying to rename (#2851)
+  * FIX: Filter sbrefs by BIDS filters if available (#2843)
+  * ENH: Provide free memory estimate to unwarp_wf for better resources allocation (#2910)
+  * ENH: Add migas telemetry in addition to sentry (#2817)
+  * ENH: Tag memory based on data shape, annotate T2SMap (#2898)
+  * ENH: Add of carbon tracker to estimate workflow emissions (#2834)
+  * ENH: Output BOLD HMC transforms and reference volume (#2860)
+  * RF: CIFTI generation (#2884)
+  * DOC: Correct description of --longitudinal behavior (#2905)
+  * MNT: Update fast track outputs, use latest smriprep (#2894)
+  * MNT: Deprecate ``--topup-max-vols`` (#2881)
+  * MNT: Add a ``--debug pdb`` to allow easier line-by-line debugging (#2871)
+  * MNT: Generate more verbose reports (here, showing fieldmaps) if running in debug mode (#2872)
+  * DOCKER: Build wheel and install in two-stage build (#2859)
+  * CI: Various updates (#2899)
+  * CI: Test on Python 3.10, bump actions versions (#2895)
+  * CI: Fix non-fasttrack outputs for maint/21.0.x (#2866)
+
+.. _`SDCFlows 2.2.0`: https://github.com/nipreps/sdcflows/releases/2.2.0
+
 22.0.2 (September 27, 2022)
 ===========================
 A patch release in the 22.0.x series.
 
 This release increases the minimum Nipype version to include better error messages on failures.
 Additionally, this includes a fix to allow SyN distortion correction in combination with the
-`--ignore fieldmaps` option.
+``--ignore fieldmaps`` option.
 
-  * MAINT: Add `pre-commit`, dev installation for consistent styling (#2857)
+  * MAINT: Add ``pre-commit``, dev installation for consistent styling (#2857)
   * CI: Upgrade docker orb (#2858)
 
 22.0.1 (September 13, 2022)


### PR DESCRIPTION
Preparation for the 22.1.0 release of fMRIPrep. I propose Monday, December 12 for release.

Outstanding issues:

* [x] Release sdcflows 2.2.0
   * [x] https://github.com/nipreps/sdcflows/pull/317
   * [x] https://github.com/nipreps/sdcflows/pull/319
   * [x] https://github.com/nipreps/sdcflows/pull/321
* [x] https://github.com/nipreps/fmriprep/pull/2898
* [x] https://github.com/nipreps/fmriprep/pull/2817
* [x] https://github.com/nipreps/fmriprep/pull/2910