### PR TITLE
ENH: Provide free memory estimate to unwarp_wf for better resources allocation

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -1112,6 +1112,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         write_coeff=True,
     )
     unwarp_wf = init_unwarp_wf(
+        free_mem=config.environment.free_mem,
         debug="fieldmaps" in config.execution.debug,
         omp_nthreads=config.nipype.omp_nthreads,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     psutil >= 5.4
     pybids >= 0.15.0
     requests
-    sdcflows ~= 2.2.0
+    sdcflows ~= 2.2.1
     smriprep ~= 0.10.0
     tedana ~= 0.0.9
     templateflow >= 0.6


### PR DESCRIPTION
## Changes proposed in this pull request

Takes advantage of nipreps/sdcflows#321 by providing an estimate of the free memory on the system to better select the number of threads to request.


## Documentation that should be reviewed
None.
