### PR TITLE
FIX: Ensure version installed in Docker file is clean

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ jobs:
               echo "the command ``git fetch --tags --verbose`` and push"
               echo "them to your fork with ``git push origin --tags``"
             fi
-            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" wrapper/fmriprep_docker.py
             # Build docker image
             e=1 && for i in {1..5}; do
               docker build --rm \
@@ -178,6 +177,21 @@ jobs:
                 --build-arg VERSION="${CIRCLE_TAG:-$THISVERSION}" . \
               && e=0 && break || sleep 15
             done && [ "$e" -eq "0" ]
+      - run:
+          name: Check Docker image
+          no_output_timeout: 60m
+          command: |
+            export PY3=$(pyenv versions | grep '3\.' |
+                         sed -e 's/.* 3\./3./' -e 's/ .*//')
+            pyenv local $PY3
+            # Get version, update files.
+            THISVERSION=$( python3 get_version.py )
+            BUILT_VERSION=$( docker run --rm nipreps/fmriprep:latest --version )
+            BUILT_VERSION=${BUILT_VERSION%$'\r'}
+            BUILT_VERSION=${BUILT_VERSION#*"fMRIPrep v"}
+            echo "VERSION: \"$THISVERSION\""
+            echo "BUILT: \"$BUILT_VERSION\""
+            test "$BUILT_VERSION" = "$THISVERSION"
       - run:
           name: Docker push to local registry
           no_output_timeout: 40m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ jobs:
             done && [ "$e" -eq "0" ]
       - run:
           name: Check Docker image
-          no_output_timeout: 60m
           command: |
             export PY3=$(pyenv versions | grep '3\.' |
                          sed -e 's/.* 3\./3./' -e 's/ .*//')
@@ -191,6 +190,7 @@ jobs:
             BUILT_VERSION=${BUILT_VERSION#*"fMRIPrep v"}
             echo "VERSION: \"$THISVERSION\""
             echo "BUILT: \"$BUILT_VERSION\""
+            set -e
             test "$BUILT_VERSION" = "$THISVERSION"
       - run:
           name: Docker push to local registry


### PR DESCRIPTION
## Changes proposed in this pull request

The last build generated a bad version number in the docker file:

```console
$ docker run --rm -it nipreps/fmriprep:22.1.0 --version
fMRIPrep v22.1.0+0.gce344b39.dirty
```

Building locally, it doesn't seem to have an issue, so it seems to be a CircleCI problem. I've resolved what I think was causing the dirty repository and also added a safeguard that should ensure future CI issues don't affect version determination.