### PR TITLE
REL: 22.1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+22.1.1 (January 04, 2023)
+=========================
+Bug fix release in the 22.1.x series.
+
+This release fixes the reported version in the distributed Docker image,
+and depends on SDCFlows 2.2.2, which fixes a bug affecting SDC estimation
+in some oblique datasets.
+
+  * FIX: Ensure version installed in Docker file is clean (#2922)
+
+
 22.1.0 (December 12, 2022)
 ==========================
 New feature release in the 22.1.x series.

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     psutil >= 5.4
     pybids >= 0.15.0
     requests
-    sdcflows ~= 2.2.1
+    sdcflows ~= 2.2.2
     smriprep ~= 0.10.0
     tedana ~= 0.0.9
     templateflow >= 0.6


### PR DESCRIPTION
Preparation for a 22.1.1 release, which fixes two small bugs. Ensuring CircleCI runs through before tagging, but will fast-forward merge into `maint/22.1.x` and tag when this passes.