### PR TITLE
MAINT: Rotate CircleCI secrets and setup up org-level context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,7 @@ jobs:
           command: |
             mkdir -p /tmp/fslicense
             cd /tmp/fslicense
-            echo "cHJpbnRmICJrcnp5c3p0b2YuZ29yZ29sZXdza2lAZ21haWwuY29tXG41MTcyXG4gKkN2dW12RVYzelRmZ1xuRlM1Si8yYzFhZ2c0RVxuIiA+IGxpY2Vuc2UudHh0Cg==" | base64 -d | sh
+            echo "${FS_LICENSE_CONTENT}" | base64 -d | sh
       - run:
           name: Create Nipype config files
           command: |
@@ -995,6 +995,8 @@ workflows:
   build_test_deploy:
     jobs:
       - build:
+          context:
+            - nipreps-common
           filters:
             branches:
               ignore:
@@ -1003,6 +1005,8 @@ workflows:
               only: /.*/
 
       - get_data:
+          context:
+            - fs-license
           filters:
             branches:
               ignore:
@@ -1013,6 +1017,8 @@ workflows:
               only: /.*/
 
       - test_deploy_pypi:
+          context:
+            - nipreps-common
           filters:
             branches:
               only:
@@ -1022,6 +1028,8 @@ workflows:
               only: /.*/
 
       - test_pytest:
+          context:
+            - nipreps-common
           requires:
             - build
           filters:
@@ -1036,6 +1044,8 @@ workflows:
               only: /.*/
 
       - ds005:
+          context:
+            - nipreps-common
           requires:
             - get_data
             - build
@@ -1051,6 +1061,8 @@ workflows:
               only: /.*/
 
       - ds054:
+          context:
+            - nipreps-common
           requires:
             - get_data
             - build
@@ -1066,6 +1078,8 @@ workflows:
               only: /.*/
 
       - ds210:
+          context:
+            - nipreps-common
           requires:
             - get_data
             - build
@@ -1082,6 +1096,8 @@ workflows:
               only: /.*/
 
       - deploy_docker_patches:
+          context:
+            - nipreps-common
           requires:
             - build
           filters:
@@ -1102,6 +1118,8 @@ workflows:
               only: /.*/
 
       - deploy_docker:
+          context:
+            - nipreps-common
           requires:
             - deployable
           filters:
@@ -1111,6 +1129,8 @@ workflows:
               only: /.*/
 
       - deploy_pypi:
+          context:
+            - nipreps-common
           requires:
             - deployable
           filters:


### PR DESCRIPTION
Responding to CircleCI's security alert on Jan 4, 2023 this PR rotates the secrets of this project.