### PR TITLE
RF: Use DataFrame.rename instead of ad hoc process

### DIFF
--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -555,12 +555,7 @@ class FMRISummary(SimpleInterface):
         else:
             data = dataframe[headers]
 
-        colnames = data.columns.ravel().tolist()
-
-        for name, newname in list(names.items()):
-            colnames[colnames.index(name)] = newname
-
-        data.columns = colnames
+        data = data.rename(columns=names)
 
         fig = fMRIPlot(
             dataset,


### PR DESCRIPTION
## Changes proposed in this pull request

We had a use of deprecated `Index.ravel()` functionality. It turns out this was to do the same thing as `DataFrame.rename(columns=mapper)`, so I just replaced that.

Closes #2904.
