### PR TITLE
MNT: Warn that AROMA support will be removed in a future version

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -31,6 +31,7 @@ def main():
     """Entry point."""
     import gc
     import sys
+    import warnings
     from multiprocessing import Manager, Process
     from os import EX_SOFTWARE
     from pathlib import Path
@@ -40,6 +41,10 @@ def main():
     from .workflow import build_workflow
 
     parse_args()
+
+    # Deprecated flags
+    if config.workflow.use_aroma:
+        warnings.warn("ICA-AROMA support will be removed in fMRIPrep 23.1.0", FutureWarning)
 
     # Code Carbon
     if config.execution.track_carbon:


### PR DESCRIPTION
## Changes proposed in this pull request

Following recent discussion. ICA-AROMA is not necessary to do within the fMRIPrep workflow, and it constrains our ability to upgrade to newer versions of FSL and/or Python as the package is very sporadically maintained. A better approach is to wrap ICA-AROMA as a post-fMRIPrep app that takes a BOLD series in MNI152NLin6Asym space and produces the outputs/reports we have up to now.

This change is not to be effected in the next release, in order to give warning that this will happen.