### PR TITLE
DOC: Update lesion ROI documentation, warn in docs and app about upcoming changes

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -226,7 +226,7 @@ To do so, follow the next steps.
 After getting the resources you'll need, you will just need to make sure your
 runtime environment is able to access the filesystem, at the location of your
 *TemplateFlow home* directory.
-If you are a Singularity user, please check out `TemplateFlow and Singularity
+If you are an Apptainer (formerly Singularity) user, please check out `TemplateFlow and Singularity
 <https://www.nipreps.org/apps/singularity/#templateflow-and-singularity>`__.
 
 How do I select only certain files to be input to *fMRIPrep*?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -226,7 +226,8 @@ To do so, follow the next steps.
 After getting the resources you'll need, you will just need to make sure your
 runtime environment is able to access the filesystem, at the location of your
 *TemplateFlow home* directory.
-If you are a Singularity user, please check out :ref:`singularity_tf`.
+If you are a Singularity user, please check out `TemplateFlow and Singularity
+<https://www.nipreps.org/apps/singularity/#templateflow-and-singularity>`__.
 
 How do I select only certain files to be input to *fMRIPrep*?
 -------------------------------------------------------------

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -79,6 +79,7 @@ single reference template (see `Longitudinal processing`_).
         ]),
         skull_strip_fixed_seed=False,
         t1w=['sub-01/anat/sub-01_T1w.nii.gz'],
+        t2w=[],
     )
 
 .. important::

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -141,9 +141,8 @@ normalization to standard space [Brett2001]_.
 ANTs will use this mask to minimize warping of healthy tissue into damaged
 areas (or vice-versa).
 Lesion masks should be binary NIfTI images (damaged areas = 1, everywhere else = 0)
-in the same space and resolution as the T1 image, and follow the naming convention specified in
-`BIDS Extension Proposal 3: Common Derivatives <https://docs.google.com/document/d/1Wwc4A6Mow4ZPPszDIWfCUCRNstn7d_zzaWPcfcHmgI4/edit#heading=h.9146wuepclkt>`_
-(e.g., ``sub-001_T1w_label-lesion_roi.nii.gz``).
+in the same space and resolution as the T1w image, and use the ``_roi`` suffix,
+for example, ``sub-001_label-lesion_roi.nii.gz``.
 This file should be placed in the ``sub-*/anat`` directory of the BIDS dataset
 to be run through *fMRIPrep*.
 Because lesion masks are not currently part of the BIDS specification, it is also necessary to
@@ -153,6 +152,20 @@ that your dataset is not valid BIDS, which prevents *fMRIPrep* from running.
 Your ``.bidsignore`` file should include the following line::
 
   *lesion_roi.nii.gz
+
+.. note::
+
+   The lesion masking instructions in this section predate the release of BIDS Derivatives.
+   As of BIDS 1.4.0, the recommended naming convention is::
+
+       manual_masks/
+       └─ sub-001/
+          └─ anat/
+             ├─ sub-001_desc-tumor_mask.nii.gz
+             └─ sub-001_desc-tumor_mask.json
+
+   In an upcoming version of fMRIPrep, we will search for lesion masks as pre-computed
+   derivatives. Until this is supported, we will continue to look for the ``_roi`` suffix.
 
 Longitudinal processing
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -202,6 +202,14 @@ reconall <{config.workflow.run_reconall}>)."""
             "All workflows require T1w images.".format(subject_id)
         )
 
+    if subject_data['roi']:
+        warnings.warn(
+            f"Lesion mask {subject_data['roi']} found. "
+            "Future versions of fMRIPrep will use alternative conventions. "
+            "Please refer to the documentation before upgrading.",
+            FutureWarning,
+        )
+
     workflow = Workflow(name=name)
     workflow.__desc__ = """
 Results included in this manuscript come from preprocessing


### PR DESCRIPTION
## Changes proposed in this pull request

* Update docs to better match BIDS conventions for lesion ROIs, but do not change existing behavior.
* Emit warning that a change will be coming and users working with this feature should check the docs before doing further upgrades.

Closes #2892.

## Documentation that should be reviewed

* Added notice that lesion ROI detection will change in an upcoming version (not 23.0).
