### PR TITLE
DOC: Altered CLI option grouping

### DIFF
--- a/.maint/contributors.json
+++ b/.maint/contributors.json
@@ -141,8 +141,8 @@
     "orcid": "0000-0002-5740-9451"
   },
   {
-    "affiliation": "Department of Psychology, Harvard University", 
-    "name": "Plunkett, Dillon", 
+    "affiliation": "Department of Psychology, Harvard University",
+    "name": "Plunkett, Dillon",
     "orcid": "0000-0001-7822-6024"
   },
   {
@@ -170,6 +170,11 @@
     "name": "Sitek, Kevin R.",
     "orcid": "0000-0002-2172-5786"
   },
+  {
+    "Affiliation": "Florey Institute of Neuroscience and Mental Health",
+    "name": "Smith, Robert E.",
+    "orcid": "0000-0003-3636-4642"
+
   {
     "affiliation": "Center for Lifespan Changes in Brain and Cognition, University of Oslo",
     "name": "Sneve, Markus H.",

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -255,20 +255,20 @@ def _build_parser(**kwargs):
     g_subset.add_argument(
         "--anat-only",
         action="store_true",
-        help="run anatomical workflows only"
+        help="Run anatomical workflows only"
     )
     g_subset.add_argument(
         "--boilerplate-only",
         "--boilerplate_only",
         action="store_true",
         default=False,
-        help="generate boilerplate only",
+        help="Generate boilerplate only",
     )
     g_subset.add_argument(
         "--reports-only",
         action="store_true",
         default=False,
-        help="only generate reports, don't run workflows. This will only rerun report "
+        help="Only generate reports, don't run workflows. This will only rerun report "
         "aggregation, not reportlet generation for specific nodes.",
     )
 
@@ -303,7 +303,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
     g_conf.add_argument(
         "--longitudinal",
         action="store_true",
-        help="treat dataset as longitudinal - may increase runtime",
+        help="Treat dataset as longitudinal - may increase runtime",
     )
     g_conf.add_argument(
         "--bold2t1w-init",
@@ -394,7 +394,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         "--md-only-boilerplate",
         action="store_true",
         default=False,
-        help="skip generation of HTML and LaTeX formatted citation with pandoc",
+        help="Skip generation of HTML and LaTeX formatted citation with pandoc",
     )
     g_outputs.add_argument(
         "--cifti-output",
@@ -496,20 +496,13 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         "--fmap-bspline",
         action="store_true",
         default=False,
-        help="fit a B-Spline field using least-squares (experimental)",
+        help="Fit a B-Spline field using least-squares (experimental)",
     )
     g_fmap.add_argument(
         "--fmap-no-demean",
         action="store_false",
         default=True,
-        help="do not remove median (within mask) from fieldmap",
-    )
-    g_fmap.add_argument(
-        "--topup-max-vols",
-        action="store",
-        default=5,
-        type=int,
-        help="maximum number of volumes to use with TOPUP, per-series (EPI or BOLD)",
+        help="Do not remove median (within mask) from fieldmap",
     )
 
     # SyN-unwarp options
@@ -587,7 +580,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         dest="verbose_count",
         action="count",
         default=0,
-        help="increases log verbosity for each occurence, debug level is -vvv",
+        help="Increases log verbosity for each occurence, debug level is -vvv",
     )
     g_other.add_argument(
         "-w",
@@ -608,7 +601,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         "--resource-monitor",
         action="store_true",
         default=False,
-        help="enable Nipype's resource monitoring to keep track of memory and CPU usage",
+        help="Enable Nipype's resource monitoring to keep track of memory and CPU usage",
     )
     g_other.add_argument(
         "--config-file",

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -144,9 +144,6 @@ def _build_parser(**kwargs):
         "fMRIPrep (see BIDS-Apps specification).",
     )
 
-    # optional arguments
-    parser.add_argument("--version", action="version", version=verstr)
-
     g_bids = parser.add_argument_group("Options for filtering BIDS queries")
     g_bids.add_argument(
         "--skip_bids_validation",
@@ -247,34 +244,32 @@ def _build_parser(**kwargs):
         type=IsFile,
         help="Nipype plugin configuration file",
     )
-    g_perfm.add_argument("--anat-only", action="store_true", help="Run anatomical workflows only")
     g_perfm.add_argument(
+        "--sloppy",
+        action="store_true",
+        default=False,
+        help="Use low-quality tools for speed - TESTING ONLY",
+    )
+
+    g_subset = parser.add_argument_group("Options for performing only a subset of the workflow")
+    g_subset.add_argument(
+        "--anat-only",
+        action="store_true",
+        help="run anatomical workflows only"
+    )
+    g_subset.add_argument(
+        "--boilerplate-only",
         "--boilerplate_only",
         action="store_true",
         default=False,
-        help="Generate boilerplate only",
+        help="generate boilerplate only",
     )
-    g_perfm.add_argument(
-        "--md-only-boilerplate",
+    g_subset.add_argument(
+        "--reports-only",
         action="store_true",
         default=False,
-        help="Skip generation of HTML and LaTeX formatted citation with pandoc",
-    )
-    g_perfm.add_argument(
-        "--error-on-aroma-warnings",
-        action="store_true",
-        dest="aroma_err_on_warn",
-        default=False,
-        help="Raise an error if ICA_AROMA does not produce sensible output "
-        "(e.g., if all the components are classified as signal or noise)",
-    )
-    g_perfm.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose_count",
-        action="count",
-        default=0,
-        help="Increases log verbosity for each occurence, debug level is -vvv",
+        help="only generate reports, don't run workflows. This will only rerun report "
+        "aggregation, not reportlet generation for specific nodes.",
     )
 
     g_conf = parser.add_argument_group("Workflow configuration")
@@ -287,11 +282,6 @@ def _build_parser(**kwargs):
         choices=["fieldmaps", "slicetiming", "sbref", "t2w", "flair"],
         help="Ignore selected aspects of the input dataset to disable corresponding "
         "parts of the workflow (a space delimited list)",
-    )
-    g_conf.add_argument(
-        "--longitudinal",
-        action="store_true",
-        help="Treat dataset as longitudinal - may increase runtime",
     )
     g_conf.add_argument(
         "--output-spaces",
@@ -311,14 +301,10 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         % (currentv.base_version if is_release else "latest"),
     )
     g_conf.add_argument(
-        "--me-output-echos",
+        "--longitudinal",
         action="store_true",
-        default=False,
-        help="""\
-Output individual echo time series with slice, motion and susceptibility correction. \
-Useful for further Tedana processing post-fMRIPrep.""",
+        help="treat dataset as longitudinal - may increase runtime",
     )
-
     g_conf.add_argument(
         "--bold2t1w-init",
         action="store",
@@ -351,23 +337,15 @@ Useful for further Tedana processing post-fMRIPrep.""",
         help="Do not use boundary-based registration (no goodness-of-fit checks)",
     )
     g_conf.add_argument(
-        "--medial-surface-nan",
-        required=False,
-        action="store_true",
-        default=False,
-        help="Replace medial wall values with NaNs on functional GIFTI files. Only "
-        "performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).",
-    )
-    g_conf.add_argument(
         "--slice-time-ref",
         required=False,
         action="store",
         default=None,
         type=SliceTimeRef,
         help="The time of the reference slice to correct BOLD values to, as a fraction "
-        "acquisition time. 0 indicates the start, 0.5 the midpoint, and 1 the end "
-        "of acquisition. The alias `start` corresponds to 0, and `middle` to 0.5. "
-        "The default value is 0.5.",
+            "acquisition time. 0 indicates the start, 0.5 the midpoint, and 1 the end "
+            "of acquisition. The alias `start` corresponds to 0, and `middle` to 0.5. "
+            "The default value is 0.5.",
     )
     g_conf.add_argument(
         "--dummy-scans",
@@ -386,7 +364,50 @@ Useful for further Tedana processing post-fMRIPrep.""",
         help="Initialize the random seed for the workflow",
     )
 
-    # ICA_AROMA options
+    g_outputs = parser.add_argument_group("Options for modulating outputs")
+    g_outputs.add_argument(
+        "--output-layout",
+        action="store",
+        default="bids",
+        choices=("bids", "legacy"),
+        help="Organization of outputs. \"bids\" (default) places fMRIPrep derivatives "
+        "directly in the output directory, and defaults to placing FreeSurfer "
+        "derivatives in <output-dir>/sourcedata/freesurfer. \"legacy\" creates "
+        "derivative datasets as subdirectories of outputs."
+    )
+    g_outputs.add_argument(
+        "--me-output-echos",
+        action="store_true",
+        default=False,
+        help="Output individual echo time series with slice, motion and susceptibility "
+        "correction. Useful for further Tedana processing post-fMRIPrep."
+    )
+    g_outputs.add_argument(
+        "--medial-surface-nan",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Replace medial wall values with NaNs on functional GIFTI files. Only "
+        "performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).",
+    )
+    g_outputs.add_argument(
+        "--md-only-boilerplate",
+        action="store_true",
+        default=False,
+        help="skip generation of HTML and LaTeX formatted citation with pandoc",
+    )
+    g_outputs.add_argument(
+        "--cifti-output",
+        nargs="?",
+        const="91k",
+        default=False,
+        choices=("91k", "170k"),
+        type=str,
+        help="Output preprocessed BOLD as a CIFTI dense timeseries. "
+        "Optionally, the number of grayordinate can be specified "
+        "(default is 91k, which equates to 2mm resolution)",
+    )
+
     g_aroma = parser.add_argument_group("Specific options for running ICA_AROMA")
     g_aroma.add_argument(
         "--use-aroma",
@@ -403,9 +424,16 @@ Useful for further Tedana processing post-fMRIPrep.""",
         help="Exact or maximum number of MELODIC components to estimate "
         "(positive = exact, negative = maximum)",
     )
+    g_aroma.add_argument(
+        "--error-on-aroma-warnings",
+        action="store_true",
+        dest="aroma_err_on_warn",
+        default=False,
+        help="Raise an error if ICA_AROMA does not produce sensible output "
+        "(e.g., if all the components are classified as signal or noise)",
+    )
 
-    # Confounds options
-    g_confounds = parser.add_argument_group("Specific options for generating confounds")
+    g_confounds = parser.add_argument_group("Options relating to confounds")
     g_confounds.add_argument(
         "--return-all-components",
         dest="regressors_all_comps",
@@ -436,7 +464,7 @@ Useful for further Tedana processing post-fMRIPrep.""",
         help="Threshold for flagging a frame as an outlier on the basis of standardised DVARS",
     )
 
-    #  ANTs options
+    # ANTs options
     g_ants = parser.add_argument_group("Specific options for ANTs registrations")
     g_ants.add_argument(
         "--skull-strip-template",
@@ -460,6 +488,28 @@ Useful for further Tedana processing post-fMRIPrep.""",
         help="Perform T1-weighted skull stripping ('force' ensures skull "
         "stripping, 'skip' ignores skull stripping, and 'auto' applies brain extraction "
         "based on the outcome of a heuristic to check whether the brain is already masked).",
+    )
+
+    # Fieldmap options
+    g_fmap = parser.add_argument_group("Specific options for handling fieldmaps")
+    g_fmap.add_argument(
+        "--fmap-bspline",
+        action="store_true",
+        default=False,
+        help="fit a B-Spline field using least-squares (experimental)",
+    )
+    g_fmap.add_argument(
+        "--fmap-no-demean",
+        action="store_false",
+        default=True,
+        help="do not remove median (within mask) from fieldmap",
+    )
+    g_fmap.add_argument(
+        "--topup-max-vols",
+        action="store",
+        default=5,
+        type=int,
+        help="maximum number of volumes to use with TOPUP, per-series (EPI or BOLD)",
     )
 
     # SyN-unwarp options
@@ -498,44 +548,46 @@ Useful for further Tedana processing post-fMRIPrep.""",
         help="Path to existing FreeSurfer subjects directory to reuse. "
         "(default: OUTPUT_DIR/freesurfer)",
     )
-
-    g_surfs = parser.add_argument_group("Surface preprocessing options")
-    g_surfs.add_argument(
+    g_fs.add_argument(
         "--no-submm-recon",
         action="store_false",
         dest="hires",
         help="Disable sub-millimeter (hires) reconstruction",
     )
-    # Surface generation xor
-    g_surfs_xor = g_surfs.add_mutually_exclusive_group()
-    g_surfs_xor.add_argument(
-        "--cifti-output",
-        nargs="?",
-        const="91k",
-        default=False,
-        choices=("91k", "170k"),
-        type=str,
-        help="Output preprocessed BOLD as a CIFTI dense timeseries. "
-        "Optionally, the number of grayordinate can be specified "
-        "(default is 91k, which equates to 2mm resolution)",
-    )
-    g_surfs_xor.add_argument(
+    g_fs.add_argument(
         "--fs-no-reconall",
         action="store_false",
         dest="run_reconall",
         help="Disable FreeSurfer surface preprocessing.",
     )
 
+    g_carbon = parser.add_argument_group("Options for carbon usage tracking")
+    g_carbon.add_argument(
+        "--track-carbon",
+        action="store_true",
+        help="Tracks power draws using CodeCarbon package",
+    )
+    g_carbon.add_argument(
+        "--country-code",
+        action="store",
+        default="CAN",
+        type=str,
+        help="Country ISO code used by carbon trackers",
+    )
+
     g_other = parser.add_argument_group("Other options")
     g_other.add_argument(
-        "--output-layout",
-        action="store",
-        default="bids",
-        choices=("bids", "legacy"),
-        help="Organization of outputs. bids (default) places fMRIPrep derivatives "
-        "directly in the output directory, and defaults to placing FreeSurfer "
-        "derivatives in <output-dir>/sourcedata/freesurfer. legacy creates "
-        "derivative datasets as subdirectories of outputs.",
+        "--version",
+        action="version",
+        version=verstr
+    )
+    g_other.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose_count",
+        action="count",
+        default=0,
+        help="increases log verbosity for each occurence, debug level is -vvv",
     )
     g_other.add_argument(
         "-w",
@@ -556,14 +608,7 @@ Useful for further Tedana processing post-fMRIPrep.""",
         "--resource-monitor",
         action="store_true",
         default=False,
-        help="Enable Nipype's resource monitoring to keep track of memory and CPU usage",
-    )
-    g_other.add_argument(
-        "--reports-only",
-        action="store_true",
-        default=False,
-        help="Only generate reports, don't run workflows. This will only rerun report "
-        "aggregation, not reportlet generation for specific nodes.",
+        help="enable Nipype's resource monitoring to keep track of memory and CPU usage",
     )
     g_other.add_argument(
         "--config-file",
@@ -599,27 +644,6 @@ Useful for further Tedana processing post-fMRIPrep.""",
         nargs="+",
         choices=config.DEBUG_MODES + ("all",),
         help="Debug mode(s) to enable. 'all' is alias for all available modes.",
-    )
-
-    g_other.add_argument(
-        "--sloppy",
-        action="store_true",
-        default=False,
-        help="Use low-quality tools for speed - TESTING ONLY",
-    )
-
-    # Carbon tracker options
-    g_other.add_argument(
-        "--track-carbon",
-        action="store_true",
-        help="Tracks power draws using CodeCarbon package",
-    )
-    g_other.add_argument(
-        "--country-code",
-        action="store",
-        default="CAN",
-        type=str,
-        help="Country ISO code used by carbon trackers",
     )
 
     latest = check_latest()

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -252,11 +252,7 @@ def _build_parser(**kwargs):
     )
 
     g_subset = parser.add_argument_group("Options for performing only a subset of the workflow")
-    g_subset.add_argument(
-        "--anat-only",
-        action="store_true",
-        help="Run anatomical workflows only"
-    )
+    g_subset.add_argument("--anat-only", action="store_true", help="Run anatomical workflows only")
     g_subset.add_argument(
         "--boilerplate-only",
         "--boilerplate_only",
@@ -343,9 +339,9 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         default=None,
         type=SliceTimeRef,
         help="The time of the reference slice to correct BOLD values to, as a fraction "
-            "acquisition time. 0 indicates the start, 0.5 the midpoint, and 1 the end "
-            "of acquisition. The alias `start` corresponds to 0, and `middle` to 0.5. "
-            "The default value is 0.5.",
+        "acquisition time. 0 indicates the start, 0.5 the midpoint, and 1 the end "
+        "of acquisition. The alias `start` corresponds to 0, and `middle` to 0.5. "
+        "The default value is 0.5.",
     )
     g_conf.add_argument(
         "--dummy-scans",
@@ -373,14 +369,14 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         help="Organization of outputs. \"bids\" (default) places fMRIPrep derivatives "
         "directly in the output directory, and defaults to placing FreeSurfer "
         "derivatives in <output-dir>/sourcedata/freesurfer. \"legacy\" creates "
-        "derivative datasets as subdirectories of outputs."
+        "derivative datasets as subdirectories of outputs.",
     )
     g_outputs.add_argument(
         "--me-output-echos",
         action="store_true",
         default=False,
         help="Output individual echo time series with slice, motion and susceptibility "
-        "correction. Useful for further Tedana processing post-fMRIPrep."
+        "correction. Useful for further Tedana processing post-fMRIPrep.",
     )
     g_outputs.add_argument(
         "--medial-surface-nan",
@@ -569,11 +565,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
     )
 
     g_other = parser.add_argument_group("Other options")
-    g_other.add_argument(
-        "--version",
-        action="version",
-        version=verstr
-    )
+    g_other.add_argument("--version", action="version", version=verstr)
     g_other.add_argument(
         "-v",
         "--verbose",


### PR DESCRIPTION
Back when I commenced some work on #2207 (from which I'll need to familiarise myself with #2913), I started by looking at the CLI and thinking about what the right interface would be for such a capability (see eg. #2805, #2806). I immediately found some command-line options that really felt as though they were in the wrong place. So here I've separated out the set of CLI changes that I'd generated in the course of that little experiment.

The git diff is quite unclean, so I've produced the set of options that would be moved and their corresponding old and new option groups. 

| Option                      | Old option group              | New option group                                     |
|-----------------------------|-------------------------------|------------------------------------------------------|
| `--anat-only`               | Options to handle performance | Options for performing only a subset of the workflow |
| `--boilerplate-only`        | Options to handle performance | Options for performing only a subset of the workflow |
| `--md-only-boilerplate`     | Options to handle performance | Options for modulating outputs                       |
| `--cifti-output`            | Surface preprocessing options | Workflow configuration              |
| `--error-on-aroma-warnings` | Options to handle performance | Specific options for running ICA_AROMA               |
| `--verbose`                 | Options to handle performance | Other options                                        |
| `--me-output-echos`         | Workflow configuration        | Options for modulating outputs                       |
| `--medial-surface-nan`      | Workflow configuration        | Options for modulating outputs                       |
| `--no-submm-recon`          | Surface preprocessing options | Specific options for FreeSurfer processing           |
| `--output-layout`           | Other options                 | Options for modulating outputs                       |
| `--sloppy`                  | Other options                 | Options to handle performance                        |
| `--track-carbon`            | Other options                 | Options for carbon tracking                          |
| `--country-code`            | Other options                 | Options for carbon tracking                          |

New option groups:
-   "Options for performing only a subset of the workflow"
-   "Options for modulating outputs"
-   "Options for carbon tracking"

Deleted option groups:
-   "Surface preprocessing options"

In particular, "Options for performing only a subset of the workflow" is what I was looking for in the context of #2207, where I had initially added command-line options "`--fmri_withhold`" and "`--fmri_regenerate`" (the naming of such options should perhaps be discussed in #2913).

Open to modification of proposed changes, or indeed addition of other changes (since this would be a good opportunity to review placement of the complete set of command-line options). For instance I'm currently looking at `[ --output-spaces, --cifti-output, --me-output-echos ]` as a candidate option group.
