### PR TITLE
FIX: Pass reference image to unwarp_wf, use reference fieldwarp for single shot

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -1173,6 +1173,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (initial_boldref_wf, coeff2epi_wf, [
             ("outputnode.ref_image", "inputnode.target_ref"),
             ("outputnode.bold_mask", "inputnode.target_mask")]),
+        (initial_boldref_wf, unwarp_wf, [
+            ("outputnode.ref_image", "inputnode.distorted_ref"),
+        ]),
         (coeff2epi_wf, unwarp_wf, [
             ("outputnode.fmap_coeff", "inputnode.fmap_coeff")]),
         (bold_hmc_wf, unwarp_wf, [
@@ -1266,11 +1269,11 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ]),
             (unwarp_wf, bold_t1_trans_wf, [
                 # TEMPORARY: For the moment we can't use frame-wise fieldmaps
-                (("outputnode.fieldwarp", pop_file), "inputnode.fieldwarp"),
+                (("outputnode.fieldwarp_ref", pop_file), "inputnode.fieldwarp"),
             ]),
             (unwarp_wf, bold_std_trans_wf, [
                 # TEMPORARY: For the moment we can't use frame-wise fieldmaps
-                (("outputnode.fieldwarp", pop_file), "inputnode.fieldwarp"),
+                (("outputnode.fieldwarp_ref", pop_file), "inputnode.fieldwarp"),
             ]),
         ])
         # fmt:on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "psutil >= 5.4",
     "pybids >= 0.15.2",
     "requests",
-    "sdcflows ~= 2.2.2",
+    "sdcflows ~= 2.3.0",
     "smriprep @ git+https://github.com/nipreps/smriprep.git@master",
     "tedana ~= 0.0.9",
     "templateflow >= 23.0.0",


### PR DESCRIPTION
## Changes proposed in this pull request

Hook up to https://github.com/nipreps/sdcflows/pull/334.

This is a workflow change, so requires a minor release bump for sdcflows and fmriprep.

This is based on reviewing the analysis provided by @sgiavasis and his group.

## Documentation that should be reviewed

None.
