### PR TITLE
ENH: Resample morphometrics to fsLR dscalar CIFTI-2 files if `--cifti-output` is used

### DIFF
--- a/.circleci/ds005_legacy_partial_outputs.txt
+++ b/.circleci/ds005_legacy_partial_outputs.txt
@@ -42,6 +42,12 @@ fmriprep/sub-01/anat/sub-01_hemi-R_thickness.shape.gii
 fmriprep/sub-01/anat/sub-01_label-CSF_probseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-GM_probseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-WM_probseg.nii.gz
+fmriprep/sub-01/anat/sub-01_space-fsLR_den-91k_curv.dscalar.nii
+fmriprep/sub-01/anat/sub-01_space-fsLR_den-91k_curv.json
+fmriprep/sub-01/anat/sub-01_space-fsLR_den-91k_sulc.dscalar.nii
+fmriprep/sub-01/anat/sub-01_space-fsLR_den-91k_sulc.json
+fmriprep/sub-01/anat/sub-01_space-fsLR_den-91k_thickness.dscalar.nii
+fmriprep/sub-01/anat/sub-01_space-fsLR_den-91k_thickness.json
 fmriprep/sub-01/anat/sub-01_space-MNI152NLin2009cAsym_desc-brain_mask.json
 fmriprep/sub-01/anat/sub-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
 fmriprep/sub-01/anat/sub-01_space-MNI152NLin2009cAsym_desc-preproc_T1w.json

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -318,6 +318,7 @@ It is released under the [CC0]\
         spaces=spaces,
         t1w=subject_data['t1w'],
         t2w=subject_data['t2w'],
+        cifti_output=config.workflow.cifti_output,
     )
     # fmt:off
     workflow.connect([

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "nipype >= 1.8.5",
     "nitime",
     "nitransforms >= 21.0.0",
-    "niworkflows ~= 1.7.0",
+    "niworkflows @ git+https://github.com/nipreps/niworkflows.git@master",
     "numpy",
     "packaging",
     "pandas",


### PR DESCRIPTION
## Changes proposed in this pull request

Depends on https://github.com/nipreps/smriprep/pull/325


## Documentation that should be reviewed
