### PR TITLE
FIX: Estimate free memory with "available", not "free"

### DIFF
--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -178,7 +178,7 @@ _templateflow_home = Path(
 try:
     from psutil import virtual_memory
 
-    _free_mem_at_start = round(virtual_memory().free / 1024**3, 1)
+    _free_mem_at_start = round(virtual_memory().available / 1024**3, 1)
 except Exception:
     _free_mem_at_start = None
 


### PR DESCRIPTION
## Changes proposed in this pull request

According to the [psutil docs](https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory):

> Return statistics about system memory usage as a named tuple including the following fields, expressed in bytes. Main metrics:
> 
> * total: total physical memory (exclusive swap).
> * available: the memory that can be given instantly to processes without the system going into swap. This is calculated by summing different memory values depending on the platform and it is supposed to be used to monitor actual memory usage in a cross platform fashion.
> 
> Other metrics:
> 
> * used: memory used, calculated differently depending on the platform and designed for informational purposes only. total - free does not necessarily match used.
> * free: memory not being used at all (zeroed) that is readily available; note that this doesn’t reflect the actual memory available (use available instead). total - used does not necessarily match free.

Running locally, `virtual_memory().available` matches what I see in `top`, not `virtual_memory().free`.

This was found while debugging an issue with `unwarp_wf.resample`, which selects `num_threads` based on the memory available.
