### PR TITLE
FIX: Dilate BOLD mask by 2 voxels to prevent over-aggressive masking degrading T2* map estimation

### DIFF
--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -86,6 +86,7 @@ def init_bold_t2s_wf(
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+    from niworkflows.interfaces.morphology import BinaryDilation
 
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
@@ -105,6 +106,8 @@ The optimally combined time series was carried forward as the *preprocessed BOLD
 
     LOGGER.log(25, 'Generating T2* map and optimally combined ME-EPI time series.')
 
+    dilate_mask = pe.Node(BinaryDilation(radius=2), name='dilate_mask')
+
     t2smap_node = pe.Node(
         T2SMap(echo_times=list(echo_times)),
         name='t2smap_node',
@@ -112,8 +115,9 @@ The optimally combined time series was carried forward as the *preprocessed BOLD
     )
     # fmt:off
     workflow.connect([
-        (inputnode, t2smap_node, [('bold_file', 'in_files'),
-                                  ('bold_mask', 'mask_file')]),
+        (inputnode, dilate_mask, [('bold_mask', 'in_mask')]),
+        (inputnode, t2smap_node, [('bold_file', 'in_files')]),
+        (dilate_mask, t2smap_node, [('out_mask', 'mask_file')]),
         (t2smap_node, outputnode, [('optimal_comb', 'bold'),
                                    ('t2star_map', 't2star_map')]),
     ])


### PR DESCRIPTION
## Changes proposed in this pull request

Dilates BOLD mask by two voxels before passing to tedana's `t2smap` command. This accounts for BOLD masking sometimes being overly aggressive. Tedana is tolerant of a relaxed mask, so this is cheaper than attempting to rework mask generation to cover more cases without becoming worse in others.

Could consider dilating by more voxels to reduce the odds of clipping further.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
