### PR TITLE
FIX: Mask BOLD with goodvoxels, not goodvoxels+ribbon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,8 +887,10 @@ jobs:
           name: Deploy to Docker Hub
           no_output_timeout: 40m
           command: |
-            docker tag nipreps/fmriprep nipreps/fmriprep:${CIRCLE_BRANCH#docker/}
-            docker push nipreps/fmriprep:${CIRCLE_BRANCH#docker/}
+            # Format: docker/[<version-like>+]<tag> -> nipreps/fmriprep:<tag>
+            # <version-like>+<tag> guides setuptools_scm to get the right major/minor
+            docker tag nipreps/fmriprep nipreps/fmriprep:${CIRCLE_BRANCH##*[/+]}
+            docker push nipreps/fmriprep:${CIRCLE_BRANCH##*[/+]}
 
   deploy_docker:
     <<: *machine_defaults

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -178,7 +178,7 @@ _templateflow_home = Path(
 try:
     from psutil import virtual_memory
 
-    _free_mem_at_start = round(virtual_memory().free / 1024**3, 1)
+    _free_mem_at_start = round(virtual_memory().available / 1024**3, 1)
 except Exception:
     _free_mem_at_start = None
 

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -571,7 +571,7 @@ def init_goodvoxels_bold_mask_wf(mem_gb: float, name: str = "goodvoxels_bold_mas
         [
             (goodvoxels_mask, goodvoxels_ribbon_mask, [("out_file", "in_file")]),
             (ribbon_boldsrc_xfm, goodvoxels_ribbon_mask, [("output_image", "mask_file")]),
-            (goodvoxels_ribbon_mask, apply_goodvoxels_ribbon_mask, [("out_file", "mask_file")]),
+            (goodvoxels_mask, apply_goodvoxels_ribbon_mask, [("out_file", "mask_file")]),
             (inputnode, apply_goodvoxels_ribbon_mask, [("bold_file", "in_file")]),
             (apply_goodvoxels_ribbon_mask, outputnode, [("out_file", "masked_bold")]),
             (goodvoxels_ribbon_mask, outputnode, [("out_file", "goodvoxels_ribbon")]),


### PR DESCRIPTION
## Changes proposed in this pull request

We have a stage where we mask the BOLD image before resampling to the surface. We should use the goodvoxels mask, not the goodvoxels_ribbon mask.

Fixes #2990.


## Documentation that should be reviewed