### PR TITLE
FIX: Remove bad metadata input from ds_goodvoxels_mask

### DIFF
--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -764,7 +764,7 @@ def init_func_derivatives_wf(
             (inputnode, ds_goodvoxels_mask, [
                 ('source_file', 'source_file'),
                 ('goodvoxels_mask', 'in_file'),
-                ('surf_refs', 'keys')]),
+            ]),
         ])
         # fmt:on
 

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -752,6 +752,7 @@ def init_func_derivatives_wf(
                 space='T1w',
                 desc='goodvoxels',
                 suffix='mask',
+                Type='ROI',  # Metadata
                 compress=True,
                 dismiss_entities=("echo",),
             ),


### PR DESCRIPTION
## Changes proposed in this pull request

Currently we're creating the following `.json` file for `goodvoxels_mask`:

```json
{
  "keys": [
    "fsaverage5",
    "fsnative"
  ]
}
```

This is not serving any useful purpose and needs to be deleted. Looking up masks, we can put in some recommended metadata, such as the type of mask it is. I don't want to figure out sources right now.