### PR TITLE
CI: Clean up pre-release builds

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - master
-      - maint/*
   pull_request:
     branches:
       - master
-      - maint/*
 
 defaults:
   run:

--- a/.maint/ci/env.sh
+++ b/.maint/ci/env.sh
@@ -3,4 +3,4 @@ SETUP_REQUIRES="pip build"
 # Numpy and scipy upload nightly/weekly/intermittent wheels
 NIGHTLY_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"
 STAGING_WHEELS="https://pypi.anaconda.org/multibuild-wheels-staging/simple"
-PRE_PIP_FLAGS="--pre --extra-index-url $NIGHTLY_WHEELS --extra-index-url $STAGING_WHEELS"
+PRE_PIP_FLAGS="--pre --extra-index-url $NIGHTLY_WHEELS --extra-index-url $STAGING_WHEELS --prefer-binary"


### PR DESCRIPTION
Pre-release tests on GitHub actions are taking a long time, almost all in installation. It turns out the Pandas is uploading sdists, but not a full set of wheels, to nightly. This adds `--prefer-binary` to just get the latest wheel they uploaded.

Also, we don't plan to update dependencies during maintenance phases, so I'm disabling pre-release tests for `maint/` branches. If this is merged, I'll cherry-pick onto `maint/20.2.x` and `maint/23.1.x`.