### PR TITLE
DOCKER: Include 3T18yoSchwartzReactN32 FreeSurfer atlas in image

### DIFF
--- a/docker/files/freesurfer7.3.2-exclude.txt
+++ b/docker/files/freesurfer7.3.2-exclude.txt
@@ -1,9 +1,3 @@
-freesurfer/average/3T18yoSchwartzReactN32_as_orig.4dfp.hdr
-freesurfer/average/3T18yoSchwartzReactN32_as_orig.4dfp.ifh
-freesurfer/average/3T18yoSchwartzReactN32_as_orig.4dfp.img
-freesurfer/average/3T18yoSchwartzReactN32_as_orig.4dfp.img.rec
-freesurfer/average/3T18yoSchwartzReactN32_as_orig.4dfp.mat
-freesurfer/average/3T18yoSchwartzReactN32_as_orig.lst
 freesurfer/average/711-2B_as_mni_average_305.4dfp.hdr
 freesurfer/average/711-2B_as_mni_average_305.4dfp.ifh
 freesurfer/average/711-2B_as_mni_average_305.4dfp.img


### PR DESCRIPTION
## Changes proposed in this pull request

Based on a report in https://neurostars.org/t/fmriprep-v22-freesurfer-recon-all-autorecon1-talairach-transformation-failing/26004, FreeSurfer falls back to an alternative atlas for Talairach registration when the first pass fails. We've been excluding this atlas, which is a bit hostile to users.