### PR TITLE
DOC: Fix documentation and description for init_bold_grayords_wf

### DIFF
--- a/.maint/CONTRIBUTORS.md
+++ b/.maint/CONTRIBUTORS.md
@@ -34,6 +34,7 @@ Before every release, unlisted contributors will be invited again to add their n
 | Mentch            | Jeff         |  | 0000-0002-7762-8678 | Speech & Hearing Bioscience & Technology Program, Harvard University                                                                         |
 | Moodie            | Craig A.     |  | 0000-0003-0867-1469 | Department of Psychology, Stanford University                                                                                                |
 | Naveau            | Mikaël       |  | 0000-0001-6948-9068 | Cyceron, UMS 3408 (CNRS - UCBN), France                                                                                                      |
+| Nielson           | Dylan M.     |  | 0000-0003-4613-6643 | Machine Learning Team, National Institute of Mental Health, USA                                                                              |
 | Nitsch            | Alexander    |  | 0000-0002-5740-9451 | Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germany                                                                |
 | Papadopoulos      | Dimitri      |  | 0000-0002-1242-8990 | Neurospin, CEA                                                                                                                               |
 | Plunkett          | Dillon       |  | 0000-0001-7822-6024 | Department of Psychology, Harvard University                                                                                                 |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -331,6 +331,11 @@
       "orcid": "0000-0003-3007-1056"
     },
     {
+      "affiliation": "Machine Learning Team, National Institute of Mental Health",
+      "name": "Nielson, Dylan M.",
+      "orcid": "0000-0003-4613-6643"
+    },
+    {
       "affiliation": "Department of Psychology, Stanford University",
       "name": "Poldrack, Russell A.",
       "orcid": "0000-0001-6755-0259"

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -1241,19 +1241,20 @@ def init_bold_grayords_wf(
         Either ``"91k"`` or ``"170k"``, representing the total *grayordinates*.
     mem_gb : :obj:`float`
         Size of BOLD file in GB
+    repetition_time : :obj:`float`
+        Repetition time in seconds
     name : :obj:`str`
         Unique name for the subworkflow (default: ``"bold_grayords_wf"``)
 
     Inputs
     ------
+   bold_fsLR : :obj:`str`
+        List of paths to BOLD series resampled as functional GIFTI files in fsLR space
     bold_std : :obj:`str`
         List of BOLD conversions to standard spaces.
     spatial_reference : :obj:`str`
         List of unique identifiers corresponding to the BOLD standard-conversions.
-    surf_files : :obj:`str`
-        List of BOLD files resampled on the fsaverage (ico7) surfaces.
-    surf_refs :
-        List of unique identifiers corresponding to the BOLD surface-conversions.
+   
 
     Outputs
     -------
@@ -1268,15 +1269,17 @@ def init_bold_grayords_wf(
     from niworkflows.interfaces.utility import KeySelect
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """\
-*Grayordinates* files [@hcppipelines] containing {density} samples were also
-generated using the highest-resolution ``fsaverage`` as intermediate standardized
-surface space.
-""".format(
-        density=grayord_density
-    )
 
     mni_density = "2" if grayord_density == "91k" else "1"
+
+    workflow.__desc__ = """\
+*Grayordinates* files [@hcppipelines] containing {density} samples were also
+generated with surface data transformed directly to fsLR space and subcortical
+data transformed to {mni_density} mm resolution MNI152NLin6Asym space.
+""".format(
+        density=grayord_density,
+        mni_density=mni_density
+    )
 
     inputnode = pe.Node(
         niu.IdentityInterface(

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -1254,7 +1254,7 @@ def init_bold_grayords_wf(
         List of BOLD conversions to standard spaces.
     spatial_reference : :obj:`str`
         List of unique identifiers corresponding to the BOLD standard-conversions.
-   
+
 
     Outputs
     -------

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -1248,7 +1248,7 @@ def init_bold_grayords_wf(
 
     Inputs
     ------
-   bold_fsLR : :obj:`str`
+    bold_fsLR : :obj:`str`
         List of paths to BOLD series resampled as functional GIFTI files in fsLR space
     bold_std : :obj:`str`
         List of BOLD conversions to standard spaces.
@@ -1277,8 +1277,7 @@ def init_bold_grayords_wf(
 generated with surface data transformed directly to fsLR space and subcortical
 data transformed to {mni_density} mm resolution MNI152NLin6Asym space.
 """.format(
-        density=grayord_density,
-        mni_density=mni_density
+        density=grayord_density, mni_density=mni_density
     )
 
     inputnode = pe.Node(


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Update documentation for `init_bold_grayords_wf`

## Documentation that should be reviewed
Removes mention of inputs that are no longer used (`surf_files` and `surf_refs`). Adds documentation of the new `repetition_time` parameter and `bold_fsLR` input. 

Additionally, updates the description to clarify that the surface data is transformed directly to fsLR and the surface data is transformed to MNI152NLin6Asym at the appropriate resolution.

Resolves #3050. 
