### PR TITLE
PATCH: Use mutualinfo cost function for MCFLIRT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ _machine_defaults: &machine_defaults
     TZ: "/usr/share/zoneinfo/America/Los_Angeles"
     SCRATCH: "/scratch"
   machine:
-    image: ubuntu-2204:current
+    image: ubuntu-2204:2023.04.2
     docker_layer_caching: true
   working_directory: /tmp/src/fmriprep
   resource_class: large

--- a/fmriprep/workflows/bold/hmc.py
+++ b/fmriprep/workflows/bold/hmc.py
@@ -102,7 +102,7 @@ parameters) are estimated before any spatiotemporal filtering using
 
     # Head motion correction (hmc)
     mcflirt = pe.Node(
-        fsl.MCFLIRT(save_mats=True, save_plots=True, save_rms=True),
+        fsl.MCFLIRT(save_mats=True, save_plots=True, save_rms=True, cost='mutualinfo'),
         name='mcflirt',
         mem_gb=mem_gb * 3,
     )


### PR DESCRIPTION
Testing out a super quick fix for #3056. This is not the long-term fix, which will be to stop using sbrefs at HMC and start with coregistration.