### PR TITLE
ENH: insert gradunwarp in bold workflow

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -282,9 +282,7 @@ def _build_parser(**kwargs):
     g_conf.add_argument(
         "--gradunwarp-file",
         metavar="PATH",
-        type=Path,
-        help="Path to vendor file for gradunwarp gradient distortion "
-        "correction.",
+        help="Path to vendor file for gradunwarp gradient distortion  correction.",
     )
     g_conf.add_argument(
         "--output-spaces",

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -280,6 +280,13 @@ def _build_parser(**kwargs):
         "parts of the workflow (a space delimited list)",
     )
     g_conf.add_argument(
+        "--gradunwarp-file",
+        metavar="PATH",
+        type=Path,
+        help="Path to vendor file for gradunwarp gradient distortion "
+        "correction.",
+    )
+    g_conf.add_argument(
         "--output-spaces",
         nargs="*",
         action=OutputReferencesAction,

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -536,7 +536,9 @@ class workflow(_Config):
     ignore = None
     """Ignore particular steps for *fMRIPrep*."""
     longitudinal = False
-    """Run FreeSurfer ``recon-all`` with the ``-logitudinal`` flag."""
+    """Run FreeSurfer ``recon-all`` with the ``-longitudinal`` flag."""
+    gradunwarp_file = None
+    """Run GradUnwarp using the provided gradient or coefficient file"""
     medial_surface_nan = None
     """Fill medial surface with :abbr:`NaNs (not-a-number)` when sampling."""
     project_goodvoxels = False

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -319,6 +319,7 @@ It is released under the [CC0]\
         spaces=spaces,
         t1w=subject_data['t1w'],
         t2w=subject_data['t2w'],
+        flair=subject_data['flair'],
         gradunwarp_file=config.workflow.gradunwarp_file,
         cifti_output=config.workflow.cifti_output,
     )

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -319,6 +319,7 @@ It is released under the [CC0]\
         spaces=spaces,
         t1w=subject_data['t1w'],
         t2w=subject_data['t2w'],
+        gradunwarp_file=config.workflow.gradunwarp_file,
         cifti_output=config.workflow.cifti_output,
     )
     # fmt:off

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -111,6 +111,8 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
         LTA-style affine matrix translating from T1w to FreeSurfer-conformed subject space
     fsnative2t1w_xfm
         LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
+    gradunwarp_file
+        Vendor provided .coeff or .grad file for gradient distortion correction.
 
     Outputs
     -------
@@ -187,6 +189,7 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False):
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+    from niworkflows.workflows.gradunwarp import init_gradunwarp_wf
     from niworkflows.func.util import init_bold_reference_wf
     from niworkflows.interfaces.nibabel import ApplyMask
     from niworkflows.interfaces.reportlets.registration import (
@@ -478,6 +481,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     # Top-level BOLD splitter
     bold_split = pe.Node(FSLSplit(dimension="t"), name="bold_split", mem_gb=mem_gb["filesize"] * 3)
 
+    # Gradient unwarping
+    if config.workflow.gradunwarp_file:
+        gradunwarp_wf = init_gradunwarp_wf()
+        gradunwarp_wf.inputs.inputnode.grad_file = gradunwarp_file
+        workflow.connect(
+            [(initial_boldref_wf, gradunwarp_wf, [('raw_ref_image', 'in_file')])]
+        )
+
     # HMC on the BOLD
     bold_hmc_wf = init_bold_hmc_wf(
         name="bold_hmc_wf", mem_gb=mem_gb["filesize"], omp_nthreads=omp_nthreads
@@ -505,6 +516,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         use_compression=False,
     )
     bold_t1_trans_wf.inputs.inputnode.fieldwarp = "identity"
+    bold_t1_trans_wf.inputs.inputnode.gradient_warp = "identity"
 
     # get confounds
     bold_confounds_wf = init_bold_confs_wf(
@@ -779,6 +791,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             use_compression=not config.execution.low_mem,
         )
         bold_std_trans_wf.inputs.inputnode.fieldwarp = "identity"
+        bold_std_trans_wf.inputs.inputnode.gradient_warp = "identity"
 
         # fmt:off
         workflow.connect([
@@ -1010,6 +1023,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             name="bold_bold_trans_wf",
         )
         bold_bold_trans_wf.inputs.inputnode.fieldwarp = "identity"
+        bold_bold_trans_wf.inputs.inputnode.gradient_warp = "identity"
 
         # fmt:off
         workflow.connect([

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -325,6 +325,7 @@ def init_bold_t1_trans_wf(
                 't1w_aparc',
                 'bold_split',
                 'fieldwarp',
+                'gradient_warp',
                 'hmc_xforms',
                 'itk_bold_to_t1',
             ]
@@ -400,7 +401,7 @@ def init_bold_t1_trans_wf(
 
     # Merge transforms placing the head motion correction last
     merge_xforms = pe.Node(
-        niu.Merge(3),
+        niu.Merge(4),
         name='merge_xforms',
         run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
@@ -409,6 +410,7 @@ def init_bold_t1_trans_wf(
     workflow.connect([
         (inputnode, merge, [('name_source', 'header_source')]),
         (inputnode, merge_xforms, [
+            ('fieldwarp', 'in4'),  # May be 'identity' if no gradunwarp applied
             ('hmc_xforms', 'in3'),  # May be 'identity' if HMC already applied
             ('fieldwarp', 'in2'),   # May be 'identity' if SDC already applied
             ('itk_bold_to_t1', 'in1')]),

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -912,6 +912,7 @@ preprocessed BOLD runs*: {tpl}.
                 "bold_split",
                 "t2star",
                 "fieldwarp",
+                "gradient_warp",
                 "hmc_xforms",
                 "itk_bold_to_t1",
                 "name_source",
@@ -964,7 +965,7 @@ preprocessed BOLD runs*: {tpl}.
     )
 
     merge_xforms = pe.Node(
-        niu.Merge(4),
+        niu.Merge(5),
         name="merge_xforms",
         run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
@@ -994,7 +995,8 @@ preprocessed BOLD runs*: {tpl}.
                                  ("templates", "keys")]),
         (inputnode, mask_std_tfm, [("bold_mask", "input_image")]),
         (inputnode, gen_ref, [(("bold_split", _first), "moving_image")]),
-        (inputnode, merge_xforms, [("hmc_xforms", "in4"),
+        (inputnode, merge_xforms, [("gradient_warp", "in5"),
+                                   ("hmc_xforms", "in4"),
                                    ("fieldwarp", "in3"),
                                    (("itk_bold_to_t1", _aslist), "in2")]),
         (inputnode, merge, [("name_source", "header_source")]),
@@ -1170,7 +1172,9 @@ the transforms to correct for head-motion"""
     )
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["name_source", "bold_file", "hmc_xforms", "fieldwarp"]),
+        niu.IdentityInterface(
+            fields=["name_source", "bold_file", "hmc_xforms", "fieldwarp", "gradient_warp"]
+        ),
         name="inputnode",
     )
 
@@ -1203,7 +1207,8 @@ the transforms to correct for head-motion"""
     # fmt:off
     workflow.connect([
         (inputnode, merge_xforms, [("fieldwarp", "in1"),
-                                   ("hmc_xforms", "in2")]),
+                                   ("hmc_xforms", "in2"),
+                                   ("gradient_warp", "in3")]),
         (inputnode, bold_transform, [("bold_file", "input_image"),
                                      (("bold_file", _first), "reference_image")]),
         (inputnode, merge, [("name_source", "header_source")]),

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -1184,7 +1184,7 @@ the transforms to correct for head-motion"""
     )
 
     merge_xforms = pe.Node(
-        niu.Merge(2),
+        niu.Merge(3),
         name="merge_xforms",
         run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

The goal of that PR is to integrate gradient unwarping to the BOLD preprocessing workflows (and to anat workflows through update of smriprep). 
See https://github.com/nipreps/fmriprep/issues/1550.
Relies on an updated version of the gradunwarp https://github.com/bpinsard/gradunwarp/tree/fix/mem_leaks.

Unwarping is applied on the initial ref (to use a single volume, it mainly takes into account the matrix size and affine rather than image content). 
Warp-field is then passed to the bold_bold, bold_T1w, bold_std one-step resamplings.

Still a WIP: inserting gradient unwarping seems more challenging for BOLD than for anatomical images. I need to check how that integrates with sdcflows. 

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

TODO: document the option to pass a gradient coeff file. 

<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
