### PR TITLE
CI: Improve tag detection for docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -854,8 +854,10 @@ jobs:
           name: Deploy to Docker Hub
           no_output_timeout: 40m
           command: |
-            docker tag nipreps/fmriprep nipreps/fmriprep:${CIRCLE_BRANCH#docker/}
-            docker push nipreps/fmriprep:${CIRCLE_BRANCH#docker/}
+            # Format: docker/[<version-like>+]<tag> -> nipreps/fmriprep:<tag>
+            # <version-like>+<tag> guides setuptools_scm to get the right major/minor
+            docker tag nipreps/fmriprep nipreps/fmriprep:${CIRCLE_BRANCH##*[/+]}
+            docker push nipreps/fmriprep:${CIRCLE_BRANCH##*[/+]}
 
   deploy_docker:
     <<: *machine_defaults


### PR DESCRIPTION
## Changes proposed in this pull request

Since moving to hatch-vcs and the next version strategies of `setuptools_scm`, the default behavior of a new branch is to increment the minor version (or major, if the new year happens to have come). At the same time, we have rules where `docker/XYZ` produces a docker tag `nipreps/fmriprep:XYZ`.

To create a Docker branch that indicates a patch on a minor series, which will be useful for reusing work directories and testing patches before a bug-fix release, this change allows for branches named `docker/X.Y.x+tag`. For example, `docker/23.1.x+mynewpatch` would produce a version `23.1.5.devN+gHASH` and a Docker image `nipreps/fmriprep:mynewpatch`.