### PR TITLE
MNT: Depend on newer sphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,9 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
+  apt_packages:
+    - graphviz
   jobs:
     post_checkout:
       - git fetch --unshallow
@@ -14,3 +16,4 @@ python:
     - path: .
       extra_requirements:
         - doc
+    - path: wrapper/

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -628,18 +628,9 @@ the following invocation::
      A multi-modal parcellation of human cerebral cortex. Nature. 2016.
      doi:`10.1038/nature18933 <https://doi.org/10.1038/nature18933>`_
 
-  .. [Hallquist2013] Hallquist MN, Hwang K, Luna B. The Nuisance of Nuisance Regression.
-     NeuroImage. 2013. doi:`10.1016/j.neuroimage.2013.05.116
-     <https://doi.org/10.1016/j.neuroimage.2013.05.116>`_
-
   .. [Jenkinson2002] Jenkinson M, Bannister P, Brady M, Smith S. Improved optimization for the
      robust and accurate linear registration and motion correction of brain images. Neuroimage.
      2002. doi:`10.1016/s1053-8119(02)91132-8 <https://doi.org/10.1016/s1053-8119(02)91132-8>`__.
-
-  .. [Lindquist2019] Lindquist, MA, Geuter, S, and Wager, TD, Caffo, BS,
-     Modular preprocessing pipelines can reintroduce artifacts into fMRI data.
-     Human Brain Mapping. 2019. doi: `10.1002/hbm.24528
-     <https://doi.org/10.1002/hbm.24528>`_
 
   .. [Muschelli2014] Muschelli J, Nebel MB, Caffo BS, Barber AD, Pekar JJ, Mostofsky SH,
      Reduction of motion-related artifacts in resting state fMRI using aCompCor. NeuroImage. 2014.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ NiPreps = "https://www.nipreps.org/"
 [project.optional-dependencies]
 doc = [
     "pydot >= 1.2.3",
-    "sphinx >= 1.8",
+    "sphinx >= 5",
     "sphinx-argparse",
     "sphinx_rtd_theme>=0.5.2",
 ]


### PR DESCRIPTION
* Depend on Sphinx >= 5
* Add apt requirement for graphviz, to restore workflow graphs
* Build with Python 3.11, because why not?
* Remove unused references producing warnings