### PR TITLE
MNT: Pin sdcflows 2.5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "psutil >= 5.4",
     "pybids >= 0.15.2",
     "requests",
-    "sdcflows  @ git+https://github.com/nipreps/sdcflows.git@master",
+    "sdcflows  @ git+https://github.com/nipreps/sdcflows.git@maint/2.5.x",
     "smriprep @ git+https://github.com/nipreps/smriprep.git@master",
     "tedana ~= 0.0.9",
     "templateflow >= 23.0.0",


### PR DESCRIPTION
## Changes proposed in this pull request

#3075 shows that the refactor necessary to use the new `unwarp_wf` will be bigger than just adding a separate unwarp workflow for the reference. Not sure it's worth the effort, given that sdcflows `master` is in flux and I'm working with the new workflow in `next`.