### PR TITLE
ENH: Add reporting workflow for BOLD fit

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -258,7 +258,7 @@ def _build_parser(**kwargs):
         "--level",
         action="store",
         default="full",
-        choices=["minimal", "resampling", "full"],
+        # choices=["minimal", "resampling", "full"],
         help="Processing level; may be 'minimal' (nothing that can be recomputed), "
         "'resampling' (recomputable targets that aid in resampling) "
         "or 'full' (all target outputs).",

--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -11,9 +11,8 @@ sections:
       extension: [.html]
       suffix: T1w
   - bids: {datatype: figures, suffix: dseg}
-    caption: This panel shows the template T1-weighted image (if several T1w images
-      were found), with contours delineating the detected brain mask and brain tissue
-      segmentations.
+    caption: This panel shows the final, preprocessed T1-weighted image,
+      with contours delineating the detected brain mask and brain tissue segmentations.
     subtitle: Brain mask and brain tissue segmentation of the T1w
   - bids: {datatype: figures, space: .*, suffix: T1w, regex_search: True}
     caption: Spatial normalization of the T1w image to the <code>{space}</code> template.
@@ -78,7 +77,7 @@ sections:
   - bids: {datatype: figures, desc: validation, suffix: bold}
   - bids: {datatype: figures, desc: fmapCoreg, suffix: bold}
     caption: The estimated fieldmap was aligned to the corresponding EPI reference
-      with a rigid-registration process of the anatomical reference of the fieldmap,
+      with a rigid-registration process of the fieldmap reference image,
       using <code>antsRegistration</code>.
       Overlaid on top of the co-registration results, the final BOLD mask is represented
       with a red contour for reference.

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -349,7 +349,7 @@ def init_bold_fit_wf(
                 ])
                 # fmt:on
             else:
-                fmapreg_buffer.inputs.boldref2fmap_xform = boldref2fmap_xform
+                fmapreg_buffer.inputs.boldref2fmap_xfm = boldref2fmap_xform
 
             unwarp_wf = init_unwarp_wf(
                 free_mem=config.environment.free_mem,
@@ -380,6 +380,11 @@ def init_bold_fit_wf(
                 (unwarp_wf, regref_buffer, [
                     ('outputnode.corrected_mask', 'boldmask'),
                 ]),
+                (fmap_select, func_fit_reports_wf, [("fmap_ref", "inputnode.fmap_ref")]),
+                (fmapreg_buffer, func_fit_reports_wf, [
+                    ("boldref2fmap_xfm", "inputnode.boldref2fmap_xfm"),
+                ]),
+                (unwarp_wf, func_fit_reports_wf, [("outputnode.fieldmap", "inputnode.fieldmap")]),
             ])
             # fmt:on
         else:

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -196,6 +196,7 @@ def init_bold_fit_wf(
 
     summary = pe.Node(
         FunctionalSummary(
+            distortion_correction="None",  # Can override with connection
             registration=("FSL", "FreeSurfer")[config.workflow.run_reconall],
             registration_dof=config.workflow.bold2t1w_dof,
             registration_init=config.workflow.bold2t1w_init,

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -204,7 +204,7 @@ def init_bold_fit_wf(
 
         ds_hmc_boldref_wf = init_ds_boldref_wf(
             bids_root=layout.root,
-            output_dir=config.execution.output_dir,
+            output_dir=config.execution.fmriprep_dir,
             desc='hmc',
             name='ds_hmc_boldref_wf',
         )
@@ -235,7 +235,7 @@ def init_bold_fit_wf(
 
         ds_hmc_wf = init_ds_hmc_wf(
             bids_root=layout.root,
-            output_dir=config.execution.output_dir,
+            output_dir=config.execution.fmriprep_dir,
         )
         ds_hmc_wf.inputs.inputnode.source_files = [bold_file]
 
@@ -264,7 +264,7 @@ def init_bold_fit_wf(
 
         ds_coreg_boldref_wf = init_ds_boldref_wf(
             bids_root=layout.root,
-            output_dir=config.execution.output_dir,
+            output_dir=config.execution.fmriprep_dir,
             desc='coreg',
             name='ds_coreg_boldref_wf',
         )
@@ -300,7 +300,7 @@ def init_bold_fit_wf(
 
                 ds_fmapreg_wf = init_ds_registration_wf(
                     bids_root=layout.root,
-                    output_dir=config.execution.output_dir,
+                    output_dir=config.execution.fmriprep_dir,
                     source="boldref",
                     dest=fieldmap_id.replace('_', ''),
                     name="ds_fmapreg_wf",
@@ -388,7 +388,7 @@ def init_bold_fit_wf(
 
         ds_boldreg_wf = init_ds_registration_wf(
             bids_root=layout.root,
-            output_dir=config.execution.output_dir,
+            output_dir=config.execution.fmriprep_dir,
             source="boldref",
             dest="T1w",
             name="ds_boldreg_wf",

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -1194,8 +1194,8 @@ def init_bold_preproc_report_wf(
 
     """
     from nipype.algorithms.confounds import TSNR
+    from nireports.interfaces.reporting.base import SimpleBeforeAfterRPT
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.interfaces.reportlets.registration import SimpleBeforeAfterRPT
 
     from ...interfaces import DerivativesDataSink
 

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -297,7 +297,7 @@ def init_func_fit_reports_wf(
         ds_sdcreg_report = pe.Node(
             DerivativesDataSink(
                 base_directory=output_dir,
-                desc="sdcreg",
+                desc="fieldmap",
                 suffix="bold",
                 datatype="figures",
                 dismiss_entities=("echo",),

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -208,8 +208,35 @@ def init_func_fit_reports_wf(
         # May be missing
         "subject_id",
         "subjects_dir",
+        # Report snippets
+        "summary_report",
+        "validation_report",
     ]
     inputnode = pe.Node(niu.IdentityInterface(fields=inputfields), name="inputnode")
+
+    ds_summary = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc="summary",
+            datatype="figures",
+            dismiss_entities=("echo",),
+        ),
+        name="ds_report_summary",
+        run_without_submitting=True,
+        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
+
+    ds_validation = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc="validation",
+            datatype="figures",
+            dismiss_entities=("echo",),
+        ),
+        name="ds_report_validation",
+        run_without_submitting=True,
+        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
 
     # Resample anatomical references into BOLD space for plotting
     t1w_boldref = pe.Node(
@@ -244,6 +271,14 @@ def init_func_fit_reports_wf(
 
     # fmt:off
     workflow.connect([
+        (inputnode, ds_summary, [
+            ('source_file', 'source_file'),
+            ('summary_report', 'in_file'),
+        ]),
+        (inputnode, ds_validation, [
+            ('source_file', 'source_file'),
+            ('validation_report', 'in_file'),
+        ]),
         (inputnode, t1w_boldref, [
             ('t1w_preproc', 'input_image'),
             ('coreg_boldref', 'reference_image'),

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -332,7 +332,7 @@ def init_func_fit_reports_wf(
         ds_sdcreg_report = pe.Node(
             DerivativesDataSink(
                 base_directory=output_dir,
-                desc="fieldmap",
+                desc="fmapCoreg",
                 suffix="bold",
                 datatype="figures",
                 dismiss_entities=("echo",),

--- a/fmriprep/workflows/bold/reference.py
+++ b/fmriprep/workflows/bold/reference.py
@@ -94,7 +94,15 @@ using a custom methodology of *fMRIPrep*, for use in head motion correction.
         name="inputnode",
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["bold_file", "boldref", "skip_vols", "algo_dummy_scans"]),
+        niu.IdentityInterface(
+            fields=[
+                "bold_file",
+                "boldref",
+                "skip_vols",
+                "algo_dummy_scans",
+                "validation_report",
+            ]
+        ),
         name="outputnode",
     )
 
@@ -126,7 +134,10 @@ using a custom methodology of *fMRIPrep*, for use in head motion correction.
         (val_bold, gen_avg, [("out_file", "in_file")]),
         (get_dummy, gen_avg, [("t_mask", "t_mask")]),
         (get_dummy, calc_dummy_scans, [("n_dummy", "algo_dummy_scans")]),
-        (val_bold, outputnode, [("out_file", "bold_file")]),
+        (val_bold, outputnode, [
+            ("out_file", "bold_file"),
+            ("out_report", "validation_report"),
+        ]),
         (calc_dummy_scans, outputnode, [("skip_vols_num", "skip_vols")]),
         (gen_avg, outputnode, [("out_file", "boldref")]),
         (get_dummy, outputnode, [("n_dummy", "algo_dummy_scans")]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "looseversion",
     "nibabel >= 4.0.1",
     "nipype >= 1.8.5",
+    "nireports >= 23.1.0",
     "nitime",
     "nitransforms >= 21.0.0",
     "niworkflows @ git+https://github.com/nipreps/niworkflows.git@master",

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,6 +151,7 @@ markupsafe==2.1.3
     # via jinja2
 matplotlib==3.7.2
     # via
+    #   nireports
     #   nitime
     #   niworkflows
     #   seaborn
@@ -175,6 +176,7 @@ nibabel==5.1.0
     #   mapca
     #   nilearn
     #   nipype
+    #   nireports
     #   nitime
     #   nitransforms
     #   niworkflows
@@ -185,15 +187,21 @@ nibabel==5.1.0
 nilearn==0.10.1
     # via
     #   mapca
+    #   nireports
     #   niworkflows
     #   tedana
 nipype==1.8.6
     # via
     #   fmriprep
     #   fmriprep (pyproject.toml)
+    #   nireports
     #   niworkflows
     #   sdcflows
     #   smriprep
+nireports==23.1.0
+    # via
+    #   fmriprep
+    #   fmriprep (pyproject.toml)
 nitime==0.10.1
     # via
     #   fmriprep
@@ -226,6 +234,7 @@ numpy==1.25.2
     #   nibabel
     #   nilearn
     #   nipype
+    #   nireports
     #   nitime
     #   nitransforms
     #   niworkflows
@@ -262,6 +271,7 @@ pandas==2.0.3
     #   fmriprep (pyproject.toml)
     #   formulaic
     #   nilearn
+    #   nireports
     #   niworkflows
     #   pybids
     #   seaborn
@@ -291,6 +301,7 @@ pybids==0.16.3
     # via
     #   fmriprep
     #   fmriprep (pyproject.toml)
+    #   nireports
     #   niworkflows
     #   sdcflows
     #   smriprep
@@ -325,6 +336,7 @@ pywavelets==1.4.1
 pyyaml==6.0.1
     # via
     #   bokeh
+    #   nireports
     #   niworkflows
     #   smriprep
 rdflib==7.0.0
@@ -373,7 +385,9 @@ sdcflows==2.5.1
     #   fmriprep
     #   fmriprep (pyproject.toml)
 seaborn==0.12.2
-    # via niworkflows
+    # via
+    #   nireports
+    #   niworkflows
 secretstorage==3.3.3
     # via keyring
 sentry-sdk==1.29.2
@@ -393,7 +407,9 @@ smriprep==0.12.2
 sqlalchemy==2.0.20
     # via pybids
 svgutils==0.3.4
-    # via niworkflows
+    # via
+    #   nireports
+    #   niworkflows
 tedana==23.0.1
     # via
     #   fmriprep
@@ -402,6 +418,7 @@ templateflow==23.0.0
     # via
     #   fmriprep
     #   fmriprep (pyproject.toml)
+    #   nireports
     #   niworkflows
     #   sdcflows
     #   smriprep


### PR DESCRIPTION
## Changes proposed in this pull request

* Sets up scaffolding for including reports for fitting, following smriprep example.
* Adds basic SDC and coregistration reportlets.

TODO:

* [x] Use nireports
* [x] Add white matter contour and/or ribbon volume to show quality of SDC/coregistration

Results:

* [ds005](https://output.circle-artifacts.com/output/job/9e2d4c60-5fbb-4f2f-b129-280b60529159/artifacts/0/full-run/sub-01.html) (2 runs, no SDC)
* [ds005](https://output.circle-artifacts.com/output/job/9e2d4c60-5fbb-4f2f-b129-280b60529159/artifacts/0/partial-run/sub-01.html) (1 run, SyN-SDC)
* [ds054](https://output.circle-artifacts.com/output/job/9399b2c4-61f3-4d5e-b271-7a5861859779/artifacts/0/tmp/ds054/fmriprep/sub-100185_noerror.html) (2 run, phasediff)
* [ds210](https://output.circle-artifacts.com/output/job/b592d2a7-5cf6-445e-85e1-57bc722906b1/artifacts/0/tmp/ds210/fmriprep/sub-02.html) (1 run, SyN-SDC)