### PR TITLE
ENH: Add MSMSulc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,6 +242,10 @@ ENV LANG="C.UTF-8" \
 ENV MKL_NUM_THREADS=1 \
     OMP_NUM_THREADS=1
 
+# MSM HOCR (Nov 19, 2019 release)
+RUN curl -L -H "Accept: application/octet-stream" https://api.github.com/repos/ecr05/MSM_HOCR/releases/assets/16253707 -o /usr/local/bin/msm \
+    && chmod +x /usr/local/bin/msm
+
 # Installing FMRIPREP
 COPY --from=src /src/fmriprep/dist/*.whl .
 RUN pip install --no-cache-dir $( ls *.whl )[container,test]

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -425,6 +425,12 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         "Optionally, the number of grayordinate can be specified "
         "(default is 91k, which equates to 2mm resolution)",
     )
+    g_outputs.add_argument(
+        "--no-msm",
+        action="store_false",
+        dest="run_msmsulc",
+        help="Disable Multimodal Surface Matching surface registration.",
+    )
 
     g_aroma = parser.add_argument_group("[DEPRECATED] Options for running ICA_AROMA")
     g_aroma.add_argument(

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -537,6 +537,8 @@ class workflow(_Config):
     """Ignore particular steps for *fMRIPrep*."""
     longitudinal = False
     """Run FreeSurfer ``recon-all`` with the ``-logitudinal`` flag."""
+    run_msmsulc = True
+    """Run Multimodal Surface Matching surface registration."""
     medial_surface_nan = None
     """Fill medial surface with :abbr:`NaNs (not-a-number)` when sampling."""
     project_goodvoxels = False

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -576,6 +576,12 @@ class workflow(_Config):
     me_t2s_fit_method = "curvefit"
     """The method by which to estimate T2*/S0 for multi-echo data"""
 
+    @classmethod
+    def init(cls):
+        # Avoid additional runtime if not required
+        if not cls.cifti_output:
+            cls.run_msmsulc = False
+
 
 class loggers:
     """Keep loggers easily accessible (see :py:func:`init`)."""

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -312,6 +312,7 @@ It is released under the [CC0]\
         hires=config.workflow.hires,
         longitudinal=config.workflow.longitudinal,
         omp_nthreads=config.nipype.omp_nthreads,
+        msm_sulc=config.workflow.run_msmsulc,
         output_dir=fmriprep_dir,
         skull_strip_fixed_seed=config.workflow.skull_strip_fixed_seed,
         skull_strip_mode=config.workflow.skull_strip_t1w,

--- a/scripts/fetch_templates.py
+++ b/scripts/fetch_templates.py
@@ -81,11 +81,14 @@ def fetch_fsaverage():
     tpl-fsaverage/tpl-fsaverage_hemi-R_den-164k_desc-vaavg_midthickness.shape.gii
     tpl-fsaverage/tpl-fsaverage_hemi-L_den-164k_midthickness.surf.gii
     tpl-fsaverage/tpl-fsaverage_hemi-R_den-164k_midthickness.surf.gii
+    tpl-fsaverage/tpl-fsaverage_hemi-L_den-164k_sulc.shape.gii
+    tpl-fsaverage/tpl-sfaverage_hemi-R_den-164k_sulc.shape.gii
     """
     template = "fsaverage"
 
     tf.get(template, density="164k", desc="std", suffix="sphere")
     tf.get(template, density="164k", suffix="midthickness")
+    tf.get(template, density="164k", suffix="sulc")
 
 
 def fetch_fsLR():


### PR DESCRIPTION
Closes #2694 

This PR adds MSMSulc surface registration, and enables it by default. To disable it, the `--no-msm` flag has been added, and behaves similar to `--no-fs-reconall`.