### PR TITLE
DOCKER: Remove mritotal and dependencies from FreeSurfer ignore file

### DIFF
--- a/docker/files/freesurfer7.3.2-exclude.txt
+++ b/docker/files/freesurfer7.3.2-exclude.txt
@@ -842,7 +842,6 @@ freesurfer/mni/etc
 freesurfer/mni/include
 freesurfer/mni/mni.srcbuild.June2015.tgz
 freesurfer/mni/share/man
-freesurfer/mni/share/mni_autoreg
 freesurfer/mni/share/N3
 freesurfer/models
 freesurfer/python/lib/python3.8/test

--- a/docker/files/freesurfer7.3.2-exclude.txt
+++ b/docker/files/freesurfer7.3.2-exclude.txt
@@ -810,8 +810,6 @@ freesurfer/mni/bin/mincview
 freesurfer/mni/bin/mincwindow
 freesurfer/mni/bin/mnc2nii
 freesurfer/mni/bin/mritoself
-freesurfer/mni/bin/mritotal
-freesurfer/mni/bin/mritotal~
 freesurfer/mni/bin/ncdump
 freesurfer/mni/bin/ncgen
 freesurfer/mni/bin/nii2mnc

--- a/docker/files/freesurfer7.3.2-exclude.txt
+++ b/docker/files/freesurfer7.3.2-exclude.txt
@@ -838,7 +838,6 @@ freesurfer/mni/bin/xfminvert
 freesurfer/mni/bin/xfmtool
 freesurfer/mni/bin/zscore_vol
 freesurfer/mni/data
-freesurfer/mni/etc
 freesurfer/mni/include
 freesurfer/mni/mni.srcbuild.June2015.tgz
 freesurfer/mni/share/man


### PR DESCRIPTION
in total 3 lines were *removed* from "/docker/files/freesurfer7.3.2-exclude.txt"
- /freesurfer/mni/bin/mritotal
- /freesurfer/mni/etc/mni_autoreg
- /freesurfer/mni/share/mni_autoreg

Previously the following error was encountered 
`mritotal: Command not found. 
ERROR: mritotal failed, see transforms/talairach.log`
however, no error was logged in the log file.
The problem is now fixed.
The resulting docker image ran without error.

Fixes #3088.
