### PR TITLE
FIX: Eliminate distortions in phasediff images caused by unmasked fieldmap estimates

### DIFF
--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -404,6 +404,7 @@ def init_bold_fit_wf(
                 ]),
                 (fmap_select, unwarp_wf, [
                     ("fmap_coeff", "inputnode.fmap_coeff"),
+                    ("fmap_mask", "inputnode.fmap_mask"),
                 ]),
                 (enhance_boldref_wf, unwarp_wf, [
                     ('outputnode.bias_corrected_file', 'inputnode.distorted'),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "psutil >= 5.4",
     "pybids >= 0.15.2",
     "requests",
-    "sdcflows  @ git+https://github.com/nipreps/sdcflows.git@master",
+    "sdcflows  @ git+https://github.com/effigies/sdcflows.git@fix/mask-fields",
     "smriprep @ git+https://github.com/nipreps/smriprep.git@next",
     "tedana >= 0.0.9",
     "templateflow >= 23.0.0",


### PR DESCRIPTION
## Changes proposed in this pull request

To recap how fieldmaps are handled in fMRIPrep, we have multiple ways of computing a fieldmap:

1) Pepolar: (dir1, dir2) -> b-spline estimate -> field -> voxel shift map
2) Phasediff/fieldmap: field estimate -> field -> voxel shift map
3) SyN-SDC: (epi, anat) -> voxel shift map

The voxel shift map is a brittle representation, and the direct field estimate potentially contains high frequency spatial noise. We therefore have shifted to the following method:

* Fit
   1) Pepolar: (dir1, dir2) -> b-spline estimate
   2) Phasediff/fieldmap: field estimate -> field -> b-spline estimate
   3) SyN-SDC: (epi, anat) -> voxel shift map -> field -> b-spline estimate
* Apply
   * b-spline estimate -> field -> voxel shift map

The problems we're seeing in #3013, #3093, etc, occur in the application stage for case 2. Here, the field is extremely noisy outside the skull, and so we can only get a good fit of the field in-brain by fitting the splines to the masked image. Because there are peaks going to the edge of the mask, the splines actually fit peaks outside the brain, and reconstructing the field without applying the mask to the result produces nonsense that pulls EPI signal outside the brain.

The good news is that the values inside the brain are basically fine, and the main problem is that it is difficult to assess the quality with such large distortions. However, if these distortions affect the coregistration, that could also produce problems.

In any event, this PR starts to fix it. I need to test to make sure that this is not introducing regressions for pepolar or SyN-SDC.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


Fixes #3013.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
