### PR TITLE
FIX: Swap direction of fmap-EPI transform

### DIFF
--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -406,7 +406,11 @@ def init_bold_fit_wf(
                     ("fmap_coeff", "inputnode.fmap_coeff"),
                 ]),
                 (fmapreg_buffer, unwarp_wf, [
-                    ("boldref2fmap_xfm", "inputnode.data2fmap_xfm"),
+                    # This looks backwards, but unwarp_wf describes transforms in
+                    # terms of points while we (and init_coeff2epi_wf) describe them
+                    # in terms of images. Mapping fieldmap coordinates into boldref
+                    # coordinates maps the boldref image onto the fieldmap image.
+                    ("boldref2fmap_xfm", "inputnode.fmap2data_xfm"),
                 ]),
                 (enhance_boldref_wf, unwarp_wf, [
                     ('outputnode.bias_corrected_file', 'inputnode.distorted'),


### PR DESCRIPTION
## Changes proposed in this pull request

#3099 introduced a subtle bug where we applied the inverse transform of what we needed. This is because `init_unwarp_wf` and `init_coeff2epi_wf` have opposite conventions (point and image) for describing transforms.

This could be swapped in sdcflows, but I intend to replace `unwarp_wf` with our resampler, so this is just doing the job correctly in the meantime.