### PR TITLE
ENH: Restore CIFTI-2 generation

### DIFF
--- a/fmriprep/interfaces/gifti.py
+++ b/fmriprep/interfaces/gifti.py
@@ -24,7 +24,7 @@ class CreateROIOutputSpec(TraitedSpec):
 
 
 class CreateROI(SimpleInterface):
-    """Prepare GIFTI shape file for use in"""
+    """Prepare GIFTI thickness file for use as a cortical ROI"""
 
     input_spec = CreateROIInputSpec
     output_spec = CreateROIOutputSpec

--- a/fmriprep/interfaces/gifti.py
+++ b/fmriprep/interfaces/gifti.py
@@ -46,16 +46,20 @@ class CreateROI(SimpleInterface):
         # wb_command -metric-math "abs(var * -1) > 0"
         roi = np.abs(darray.data) > 0
 
+        # Divergence: Set datatype to uint8, since the values are boolean
+        # wb_command sets datatype to float32
         darray = nb.gifti.GiftiDataArray(
             roi,
             intent=darray.intent,
-            datatype=darray.datatype,
+            datatype='uint8',
             encoding=darray.encoding,
             endian=darray.endian,
             coordsys=darray.coordsys,
             ordering=darray.ind_ord,
             meta=meta,
         )
+
+        img.darrays[0] = darray
 
         out_filename = os.path.join(runtime.cwd, f"{subject}.{hemi}.roi.native.shape.gii")
         img.to_filename(out_filename)

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -507,6 +507,12 @@ tasks and sessions), the following preprocessing was performed.
                 ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                 ('outputnode.subject_id', 'inputnode.subject_id'),
                 ('outputnode.fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
+                ('outputnode.white', 'inputnode.white'),
+                ('outputnode.pial', 'inputnode.pial'),
+                ('outputnode.midthickness', 'inputnode.midthickness'),
+                ('outputnode.thickness', 'inputnode.thickness'),
+                ('outputnode.sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR'),
+                ('outputnode.anat_ribbon', 'inputnode.anat_ribbon'),
             ]),
         ])  # fmt:skip
         if fieldmap_id:

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -333,6 +333,7 @@ It is released under the [CC0]\
     ])  # fmt:skip
 
     # Set up the template iterator once, if used
+    template_iterator_wf = None
     if config.workflow.level == "full":
         if spaces.cached.get_spaces(nonstandard=False, dim=(3,)):
             template_iterator_wf = init_template_iterator_wf(spaces=spaces)
@@ -556,16 +557,17 @@ tasks and sessions), the following preprocessing was performed.
             ])  # fmt:skip
 
         if config.workflow.level == "full":
-            workflow.connect([
-                (template_iterator_wf, bold_wf, [
-                    ("outputnode.anat2std_xfm", "inputnode.anat2std_xfm"),
-                    ("outputnode.space", "inputnode.std_space"),
-                    ("outputnode.resolution", "inputnode.std_resolution"),
-                    ("outputnode.cohort", "inputnode.std_cohort"),
-                    ("outputnode.std_t1w", "inputnode.std_t1w"),
-                    ("outputnode.std_mask", "inputnode.std_mask"),
-                ]),
-            ])  # fmt:skip
+            if template_iterator_wf is not None:
+                workflow.connect([
+                    (template_iterator_wf, bold_wf, [
+                        ("outputnode.anat2std_xfm", "inputnode.anat2std_xfm"),
+                        ("outputnode.space", "inputnode.std_space"),
+                        ("outputnode.resolution", "inputnode.std_resolution"),
+                        ("outputnode.cohort", "inputnode.std_cohort"),
+                        ("outputnode.std_t1w", "inputnode.std_t1w"),
+                        ("outputnode.std_mask", "inputnode.std_mask"),
+                    ]),
+                ])  # fmt:skip
 
             # Thread MNI152NLin6Asym standard outputs to CIFTI subworkflow, skipping
             # the iterator, which targets only output spaces.

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -189,9 +189,16 @@ def init_bold_wf(
                 "t1w_mask",
                 "t1w_dseg",
                 "t1w_tpms",
+                # FreeSurfer outputs
                 "subjects_dir",
                 "subject_id",
                 "fsnative2t1w_xfm",
+                "white",
+                "midthickness",
+                "pial",
+                "thickness",
+                "sphere_reg_fsLR",
+                "anat_ribbon",
                 # Fieldmap registration
                 "fmap",
                 "fmap_ref",

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -982,30 +982,6 @@ def init_func_derivatives_wf(
         ])
         # fmt:on
 
-    # CIFTI output
-    if cifti_output:
-        ds_bold_cifti = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                suffix='bold',
-                compress=False,
-                TaskName=metadata.get('TaskName'),
-                space='fsLR',
-                **timing_parameters,
-            ),
-            name='ds_bold_cifti',
-            run_without_submitting=True,
-            mem_gb=DEFAULT_MEMORY_MIN_GB,
-        )
-        # fmt:off
-        workflow.connect([
-            (inputnode, ds_bold_cifti, [(('bold_cifti', _unlist), 'in_file'),
-                                        ('source_file', 'source_file'),
-                                        ('cifti_density', 'density'),
-                                        (('cifti_metadata', _read_json), 'meta_dict')])
-        ])
-        # fmt:on
-
     if "compcor" in config.execution.debug:
         ds_acompcor_masks = pe.Node(
             DerivativesDataSink(
@@ -1120,10 +1096,3 @@ def _unlist(in_file):
     while isinstance(in_file, (list, tuple)) and len(in_file) == 1:
         in_file = in_file[0]
     return in_file
-
-
-def _read_json(in_file):
-    from json import loads
-    from pathlib import Path
-
-    return loads(Path(in_file).read_text())

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -620,7 +620,6 @@ def init_ds_bold_native_wf(
                 **timing_parameters,
             ),
             name='ds_bold',
-            run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB,
         )
         workflow.connect([
@@ -732,7 +731,6 @@ def init_ds_volumes_wf(
             **timing_parameters,
         ),
         name='ds_bold',
-        run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
     workflow.connect([


### PR DESCRIPTION
Builds on #3126.

This one splits out the selection of the MNI template for the CIFTI-2 generation from the rest of the resampling to volumetric templates. If someone requests MNI152NLin6Asym and CIFTI, then we will resample twice in the working directory, but given that resampling is significantly faster now and does not scale files per-time point, I'm okay with that. I think it's a pretty rare case, and I suspect we'll want to resample a smaller ROI than the full brain at some point, so a separate pathway for that seems okay.