### PR TITLE
chore: update to latest migas api

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -24,8 +24,6 @@
 """fMRI preprocessing workflow."""
 from .. import config
 
-EXITCODE: int = -1
-
 
 def main():
     """Entry point."""
@@ -76,15 +74,12 @@ def main():
 
     sentry_sdk = None
     if not config.execution.notrack and not config.execution.debug:
-        import atexit
-
         import sentry_sdk
 
         from ..utils.telemetry import sentry_setup, setup_migas
 
         sentry_setup()
         setup_migas(init_ping=True)
-        atexit.register(migas_exit)
 
     # CRITICAL Save the config to a file. This is necessary because the execution graph
     # is built as a separate process to keep the memory footprint low. The most
@@ -110,8 +105,7 @@ def main():
     else:
         retval = build_workflow(str(config_file), {})
 
-    global EXITCODE
-    EXITCODE = retval.get("return_code", 0)
+    exitcode = retval.get("return_code", 0)
     fmriprep_wf = retval.get("workflow", None)
 
     # CRITICAL Load the config from the file. This is necessary because the ``build_workflow``
@@ -120,14 +114,14 @@ def main():
     config.load(config_file)
 
     if config.execution.reports_only:
-        sys.exit(int(EXITCODE > 0))
+        sys.exit(int(exitcode > 0))
 
     if fmriprep_wf and config.execution.write_graph:
         fmriprep_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
 
-    EXITCODE = EXITCODE or (fmriprep_wf is None) * EX_SOFTWARE
-    if EXITCODE != 0:
-        sys.exit(EXITCODE)
+    exitcode = exitcode or (fmriprep_wf is None) * EX_SOFTWARE
+    if exitcode != 0:
+        sys.exit(exitcode)
 
     # Generate boilerplate
     with Manager() as mgr:
@@ -138,7 +132,7 @@ def main():
         p.join()
 
     if config.execution.boilerplate_only:
-        sys.exit(int(EXITCODE > 0))
+        sys.exit(int(exitcode > 0))
 
     # Clean up master process before running workflow, which may create forks
     gc.collect()
@@ -236,37 +230,6 @@ def main():
                 level="error",
             )
         sys.exit(int((errno + failed_reports) > 0))
-
-
-def migas_exit() -> None:
-    """
-    Send a final crumb to the migas server signaling if the run successfully completed
-    This function should be registered with `atexit` to run at termination.
-    """
-    import sys
-
-    from ..utils.telemetry import send_breadcrumb
-
-    global EXITCODE
-    migas_kwargs = {'status': 'C'}
-    # `sys` will not have these attributes unless an error has been handled
-    if hasattr(sys, 'last_type'):
-        migas_kwargs = {
-            'status': 'F',
-            'status_desc': 'Finished with error(s)',
-            'error_type': sys.last_type,
-            'error_desc': sys.last_value,
-        }
-    elif EXITCODE != 0:
-        migas_kwargs.update(
-            {
-                'status': 'F',
-                'status_desc': f'Completed with exitcode {EXITCODE}',
-            }
-        )
-    else:
-        migas_kwargs['status_desc'] = 'Success'
-    send_breadcrumb(**migas_kwargs)
 
 
 if __name__ == "__main__":

--- a/fmriprep/utils/telemetry.py
+++ b/fmriprep/utils/telemetry.py
@@ -185,7 +185,7 @@ def _chunks(string, length=CHUNK_SIZE):
     return [string[i : i + length] for i in range(0, len(string), length)]
 
 
-def setup_migas(init_ping: bool = True) -> None:
+def setup_migas(init_ping: bool = True, exit_ping: bool = True) -> None:
     """
     Prepare the migas python client to communicate with a migas server.
     If ``init_ping`` is ``True``, send an initial breadcrumb.
@@ -197,12 +197,19 @@ def setup_migas(init_ping: bool = True) -> None:
 
     migas.setup(session_id=session_id)
     if init_ping:
-        send_breadcrumb(status='R', status_desc='workflow start')
+        send_crumb(status='R', status_desc='workflow start')
+    if exit_ping:
+        from migas.error.nipype import node_execution_error
+
+        migas.track_exit(
+            'nipreps/fmriprep',
+            __version__,
+            {'NodeExecutionEror', node_execution_error},
+        )
 
 
-def send_breadcrumb(**kwargs) -> dict:
+def send_crumb(**kwargs) -> dict:
     """
     Communicate with the migas telemetry server. This requires `migas.setup()` to be called.
     """
-    res = migas.add_project("nipreps/fmriprep", __version__, **kwargs)
-    return res
+    return migas.add_breadcrumb("nipreps/fmriprep", __version__, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ container = [
     "datalad-osf",
 ]
 telemetry = [
-    "migas >= 0.3.0",
+    "migas >= 0.4.0",
     "sentry-sdk >= 1.3",
 ]
 test = [


### PR DESCRIPTION
Strips away error handling logic, which has been ported to `migas.track_exit`.