### PR TITLE
MNT: update vendored docs script `github_link.py`

### DIFF
--- a/docs/sphinxext/github_link.py
+++ b/docs/sphinxext/github_link.py
@@ -1,24 +1,20 @@
-"""
-This script comes from scikit-learn:
-https://github.com/scikit-learn/scikit-learn/blob/master/doc/sphinxext/github_link.py
-"""
-from operator import attrgetter
 import inspect
-import subprocess
 import os
+import subprocess
 import sys
 from functools import partial
+from operator import attrgetter
 
-REVISION_CMD = 'git rev-parse --short HEAD'
+REVISION_CMD = "git rev-parse --short HEAD"
 
 
 def _get_git_revision():
     try:
         revision = subprocess.check_output(REVISION_CMD.split()).strip()
     except (subprocess.CalledProcessError, OSError):
-        print('Failed to execute git to get revision')
+        print("Failed to execute git to get revision")
         return None
-    return revision.decode('utf-8')
+    return revision.decode("utf-8")
 
 
 def _linkcode_resolve(domain, info, package, url_fmt, revision):
@@ -30,25 +26,26 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
     >>> _linkcode_resolve('py', {'module': 'tty',
     ...                          'fullname': 'setraw'},
     ...                   package='tty',
-    ...                   url_fmt='https://hg.python.org/cpython/file/'
+    ...                   url_fmt='http://hg.python.org/cpython/file/'
     ...                           '{revision}/Lib/{package}/{path}#L{lineno}',
     ...                   revision='xxxx')
-    'https://hg.python.org/cpython/file/xxxx/Lib/tty/tty.py#L18'
+    'http://hg.python.org/cpython/file/xxxx/Lib/tty/tty.py#L18'
     """
 
     if revision is None:
         return
-    if domain not in ('py', 'pyx'):
+    if domain not in ("py", "pyx"):
         return
-    if not info.get('module') or not info.get('fullname'):
+    if not info.get("module") or not info.get("fullname"):
         return
 
-    class_name = info['fullname'].split('.')[0]
-    if type(class_name) != str:
-        # Python 2 only
-        class_name = class_name.encode('utf-8')
-    module = __import__(info['module'], fromlist=[class_name])
-    obj = attrgetter(info['fullname'])(module)
+    class_name = info["fullname"].split(".")[0]
+    module = __import__(info["module"], fromlist=[class_name])
+    obj = attrgetter(info["fullname"])(module)
+
+    # Unwrap the object to get the correct source
+    # file in case that is wrapped by a decorator
+    obj = inspect.unwrap(obj)
 
     try:
         fn = inspect.getsourcefile(obj)
@@ -62,14 +59,12 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
     if not fn:
         return
 
-    fn = os.path.relpath(fn,
-                         start=os.path.dirname(__import__(package).__file__))
+    fn = os.path.relpath(fn, start=os.path.dirname(__import__(package).__file__))
     try:
         lineno = inspect.getsourcelines(obj)[1]
     except Exception:
-        lineno = ''
-    return url_fmt.format(revision=revision, package=package,
-                          path=fn, lineno=lineno)
+        lineno = ""
+    return url_fmt.format(revision=revision, package=package, path=fn, lineno=lineno)
 
 
 def make_linkcode_resolve(package, url_fmt):
@@ -84,5 +79,6 @@ def make_linkcode_resolve(package, url_fmt):
                                    '{path}#L{lineno}')
     """
     revision = _get_git_revision()
-    return partial(_linkcode_resolve, revision=revision, package=package,
-                   url_fmt=url_fmt)
+    return partial(
+        _linkcode_resolve, revision=revision, package=package, url_fmt=url_fmt
+    )

--- a/docs/sphinxext/github_link.py
+++ b/docs/sphinxext/github_link.py
@@ -1,3 +1,7 @@
+"""
+This vendored script comes from scikit-learn:
+https://github.com/scikit-learn/scikit-learn/blob/master/doc/sphinxext/github_link.py
+"""
 import inspect
 import os
 import subprocess


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

As far as I can see, we had just added a few lines to tell this vendored script originates in scikit-learn.
    
File initially copied in #1258, and [not changed since](https://github.com/nipreps/fmriprep/commits/master/docs/sphinxext/github_link.py), except for #3097 which I shouldn't have applied to a vendored file.