### PR TITLE
TEST: Add pytest-xdist to test dependencies, "-n auto" to CI invocations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ jobs:
             docker run -ti --rm=false \
               -e TEST_READONLY_FILESYSTEM=1 -v $HOME:/home/readonly:ro \
               --entrypoint="pytest" nipreps/fmriprep:latest \
-              --pyargs fmriprep -svx --doctest-modules
+              --pyargs fmriprep -n auto -svx --doctest-modules
 
       - run:
           name: Build fmriprep-docker wheel

--- a/.maint/ci/check.sh
+++ b/.maint/ci/check.sh
@@ -16,7 +16,7 @@ if [ "${CHECK_TYPE}" == "doc" ]; then
     make html && make doctest
 elif [ "${CHECK_TYPE}" == "tests" ]; then
     pytest --doctest-modules --cov fmriprep --cov-report xml \
-        --junitxml=test-results.xml -v fmriprep
+        --junitxml=test-results.xml -v -n auto fmriprep
 else
     false
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-env",
+    "pytest-xdist",
 ]
 maint = [
     "fuzzywuzzy",


### PR DESCRIPTION
Building and expanding the workflows has increased CI runtime to the order of 3-5 minutes. At this point it seems worth using xdist to avoid unnecessary runtime. Locally it runs fine with 10+ cores, so I don't expect this will add annoying-to-debug race conditions in. The process isolation seems to do its job.