### PR TITLE
Separate goodvoxels mask creation from fsLR resampling

### DIFF
--- a/.circleci/ds005_partial_fasttrack_outputs.txt
+++ b/.circleci/ds005_partial_fasttrack_outputs.txt
@@ -83,6 +83,8 @@ sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-prepr
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-brain_mask.nii.gz
+sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-goodvoxels_mask.nii.gz
+sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-goodvoxels_mask.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.nii.gz
 sub-01.html

--- a/.circleci/ds005_partial_fasttrack_outputs.txt
+++ b/.circleci/ds005_partial_fasttrack_outputs.txt
@@ -83,8 +83,6 @@ sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-prepr
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-brain_mask.nii.gz
-sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-goodvoxels_mask.nii.gz
-sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-goodvoxels_mask.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.nii.gz
 sub-01.html

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -543,9 +543,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ])  # fmt:skip
 
             bold_fsLR_resampling_wf.__desc__ += """\
-                A "goodvoxels" mask was applied during volume-to-surface sampling in fsLR space,
-                excluding voxels whose time-series have a locally high coefficient of variation.
-                """
+A "goodvoxels" mask was applied during volume-to-surface sampling in fsLR space,
+excluding voxels whose time-series have a locally high coefficient of variation.
+"""
 
         bold_grayords_wf = init_bold_grayords_wf(
             grayord_density=config.workflow.cifti_output,

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -460,8 +460,6 @@ configured with cubic B-spline interpolation.
                 ("outputnode.boldref2fmap_xfm", "inputnode.boldref2fmap_xfm"),
                 ("outputnode.boldref2anat_xfm", "inputnode.boldref2anat_xfm"),
             ]),
-            # XXX: The bold_file here is post-HMC+SDC, so should HMC + SDC be applied again?
-            # Should this take in the inputnode BOLD file instead?
             (bold_native_wf, bold_std_wf, [
                 ("outputnode.bold_minimal", "inputnode.bold_file"),
                 ("outputnode.motion_xfm", "inputnode.motion_xfm"),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -31,8 +31,6 @@ Orchestrating the BOLD-preprocessing workflow
 """
 import typing as ty
 
-import nibabel as nb
-import numpy as np
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.utils.connections import listify
@@ -532,7 +530,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
             workflow.connect([
                 (inputnode, goodvoxels_bold_mask_wf, [("anat_ribbon", "inputnode.anat_ribbon")]),
-                (bold_anat_wf, goodvoxels_bold_mask_wf, [("bold_file", "inputnode.bold_file")]),
+                (bold_anat_wf, goodvoxels_bold_mask_wf, [
+                    ("outputnode.bold_file", "inputnode.bold_file"),
+                ]),
                 (goodvoxels_bold_mask_wf, bold_fsLR_resampling_wf, [
                     ("outputnode.goodvoxels_mask", "inputnode.volume_roi"),
                 ]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -530,7 +530,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         )
 
         if config.workflow.project_goodvoxels:
-            goodvoxels_bold_mask_wf = init_goodvoxels_bold_mask_wf(mem_gb)
+            goodvoxels_bold_mask_wf = init_goodvoxels_bold_mask_wf(mem_gb["resampled"])
 
             workflow.connect([
                 (inputnode, goodvoxels_bold_mask_wf, [("anat_ribbon", "inputnode.anat_ribbon")]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -523,6 +523,29 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             mem_gb=mem_gb["resampled"],
         )
 
+        if config.workflow.project_goodvoxels:
+            ds_goodvoxels_mask = pe.Node(
+                DerivativesDataSink(
+                    base_directory=fmriprep_dir,
+                    space="T1w",
+                    desc="goodvoxels",
+                    suffix="mask",
+                    compress=True,
+                    dismiss_entities=("echo",),
+                    # Metadata
+                    Type="ROI",
+                ),
+                name="ds_goodvoxels_mask",
+                run_without_submitting=True,
+                mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+            )
+            ds_goodvoxels_mask.inputs.source_file = bold_file
+            workflow.connect([
+                (bold_fsLR_resampling_wf, ds_goodvoxels_mask, [
+                    ("outputnode.goodvoxels_mask", "in_file"),
+                ]),
+            ])  # fmt:skip
+
         bold_grayords_wf = init_bold_grayords_wf(
             grayord_density=config.workflow.cifti_output,
             mem_gb=1,

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -294,6 +294,7 @@ configured with cubic B-spline interpolation.
         fieldmap_id=fieldmap_id,
         omp_nthreads=omp_nthreads,
     )
+    # NOTE: Why put this in 'resampling' and not 'full'?
     bold_anat_wf = init_bold_volumetric_resample_wf(
         metadata=all_metadata[0],
         fieldmap_id=fieldmap_id if not multiecho else None,

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -531,10 +531,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             goodvoxels_bold_mask_wf = init_goodvoxels_bold_mask_wf(mem_gb)
 
             workflow.connect([
-                (inputnode, goodvoxels_bold_mask_wf, [
-                    ("bold_file", "inputnode.bold_file"),
-                    ("anat_ribbon", "inputnode.anat_ribbon"),
-                ]),
+                (inputnode, goodvoxels_bold_mask_wf, [("anat_ribbon", "inputnode.anat_ribbon")]),
+                (bold_anat_wf, goodvoxels_bold_mask_wf, [("bold_file", "inputnode.bold_file")]),
                 (goodvoxels_bold_mask_wf, bold_fsLR_resampling_wf, [
                     ("outputnode.goodvoxels_mask", "inputnode.volume_roi"),
                 ]),
@@ -593,7 +591,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ("midthickness_fsLR", "inputnode.midthickness_fsLR"),
                 ("sphere_reg_fsLR", "inputnode.sphere_reg_fsLR"),
                 ("cortex_mask", "inputnode.cortex_mask"),
-                ("anat_ribbon", "inputnode.anat_ribbon"),
             ]),
             (bold_anat_wf, bold_fsLR_resampling_wf, [
                 ("outputnode.bold_file", "inputnode.bold_file"),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -459,6 +459,8 @@ configured with cubic B-spline interpolation.
                 ("outputnode.boldref2fmap_xfm", "inputnode.boldref2fmap_xfm"),
                 ("outputnode.boldref2anat_xfm", "inputnode.boldref2anat_xfm"),
             ]),
+            # XXX: The bold_file here is post-HMC+SDC, so should HMC + SDC be applied again?
+            # Should this take in the inputnode BOLD file instead?
             (bold_native_wf, bold_std_wf, [
                 ("outputnode.bold_minimal", "inputnode.bold_file"),
                 ("outputnode.motion_xfm", "inputnode.motion_xfm"),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -525,29 +525,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             mem_gb=mem_gb["resampled"],
         )
 
-        if config.workflow.project_goodvoxels:
-            ds_goodvoxels_mask = pe.Node(
-                DerivativesDataSink(
-                    base_directory=fmriprep_dir,
-                    space="T1w",
-                    desc="goodvoxels",
-                    suffix="mask",
-                    compress=True,
-                    dismiss_entities=("echo",),
-                    # Metadata
-                    Type="ROI",
-                ),
-                name="ds_goodvoxels_mask",
-                run_without_submitting=True,
-                mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-            )
-            ds_goodvoxels_mask.inputs.source_file = bold_file
-            workflow.connect([
-                (bold_fsLR_resampling_wf, ds_goodvoxels_mask, [
-                    ("outputnode.goodvoxels_mask", "in_file"),
-                ]),
-            ])  # fmt:skip
-
         bold_grayords_wf = init_bold_grayords_wf(
             grayord_density=config.workflow.cifti_output,
             mem_gb=1,

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -544,14 +544,22 @@ def init_bold_fsLR_resampling_wf(
     ------
     bold_file : :class:`str`
         Path to BOLD file resampled into T1 space
-    surfaces : :class:`list` of :class:`str`
-        Path to left and right hemisphere white, pial and midthickness GIFTI surfaces
-    morphometrics : :class:`list` of :class:`str`
-        Path to left and right hemisphere morphometric GIFTI surfaces, which must include thickness
-    sphere_reg_fsLR : :class:`list` of :class:`str`
-        Path to left and right hemisphere sphere.reg GIFTI surfaces, mapping from subject to fsLR
     anat_ribbon : :class:`str`
         Path to mask of cortical ribbon in T1w space, for calculating goodvoxels
+    white : :class:`list` of :class:`str`
+        Path to left and right hemisphere white matter GIFTI surfaces.
+    pial : :class:`list` of :class:`str`
+        Path to left and right hemisphere pial GIFTI surfaces.
+    midthickness : :class:`list` of :class:`str`
+        Path to left and right hemisphere midthickness GIFTI surfaces.
+    midthickness_fsLR : :class:`list` of :class:`str`
+        Path to left and right hemisphere midthickness GIFTI surfaces in fsLR space.
+    sphere_reg_fsLR : :class:`list` of :class:`str`
+        Path to left and right hemisphere sphere.reg GIFTI surfaces, mapping from subject to fsLR
+    cortex_mask : :class:`list` of :class:`str`
+        Path to left and right hemisphere cortical masks.
+    goodvoxels_mask : :class:`str` or Undefined
+        Pre-calculated goodvoxels mask. Not required.
 
     Outputs
     -------
@@ -565,14 +573,8 @@ def init_bold_fsLR_resampling_wf(
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.interfaces.utility import KeySelect
     from smriprep import data as smriprep_data
-    from smriprep.interfaces.workbench import SurfaceResample
 
-    from fmriprep.interfaces.gifti import CreateROI
-    from fmriprep.interfaces.workbench import (
-        MetricFillHoles,
-        MetricRemoveIslands,
-        VolumeToSurfaceMapping,
-    )
+    from fmriprep.interfaces.workbench import VolumeToSurfaceMapping
 
     fslr_density = "32k" if grayord_density == "91k" else "59k"
 
@@ -594,6 +596,7 @@ The BOLD time-series were resampled onto the left/right-symmetric template
                 'midthickness_fsLR',
                 'sphere_reg_fsLR',
                 'cortex_mask',
+                'goodvoxels_mask',
             ]
         ),
         name='inputnode',
@@ -733,6 +736,9 @@ excluding voxels whose time-series have a locally high coefficient of variation.
                 ("outputnode.goodvoxels_mask", "goodvoxels_mask"),
             ]),
         ])  # fmt:skip
+    else:
+        # Won't have any effect if goodvoxels_mask is Undefined.
+        workflow.connect([(inputnode, volume_to_surface, ('goodvoxels_mask', 'volume_roi'))])
 
     return workflow
 

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -539,8 +539,6 @@ def init_bold_fsLR_resampling_wf(
     ------
     bold_file : :class:`str`
         Path to BOLD file resampled into T1 space
-    anat_ribbon : :class:`str`
-        Path to mask of cortical ribbon in T1w space, for calculating goodvoxels
     white : :class:`list` of :class:`str`
         Path to left and right hemisphere white matter GIFTI surfaces.
     pial : :class:`list` of :class:`str`
@@ -582,7 +580,6 @@ The BOLD time-series were resampled onto the left/right-symmetric template
         niu.IdentityInterface(
             fields=[
                 'bold_file',
-                'anat_ribbon',
                 'white',
                 'pial',
                 'midthickness',

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -738,7 +738,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
         ])  # fmt:skip
     else:
         # Won't have any effect if goodvoxels_mask is Undefined.
-        workflow.connect([(inputnode, volume_to_surface, ('goodvoxels_mask', 'volume_roi'))])
+        workflow.connect([(inputnode, volume_to_surface, [('goodvoxels_mask', 'volume_roi')])])
 
     return workflow
 


### PR DESCRIPTION
Closes #3169. This could just be a first step toward moving one or more of these workflows from fMRIPrep to niworkflows.

## Changes proposed in this pull request

- Move `init_goodvoxels_bold_mask_wf` call out of `init_bold_fsLR_resampling_wf`. This will allow downstream tools (e.g., ASLPrep) to generate the goodvoxels mask from one file (the ASL time series) and apply it to others (e.g., CBF maps).
- Clean up `init_bold_fsLR_resampling_wf` (e.g., remove unused imports and add all parameters to docstring).
- Move BOLD-to-anatomical resampling workflow call from `resampling` level to `full` level, since it doesn't produce any outputs.