### PR TITLE
Exclude non-steady-state volumes from confound correlation plot

### DIFF
--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -591,6 +591,7 @@ the edge of the brain, as proposed by [@patriat_improved_2017].
         (crowncompcor, mrg_cc_metadata, [("metadata_file", "in3")]),
         (mrg_cc_metadata, compcor_plot, [("out", "metadata_files")]),
         (compcor_plot, ds_report_compcor, [("out_file", "in_file")]),
+        (inputnode, conf_corr_plot, [("skip_vols", "ignore_initial_volumes")]),
         (concat, conf_corr_plot, [("confounds_file", "confounds_file"),
                                   (("confounds_file", _select_cols), "columns")]),
         (conf_corr_plot, ds_report_conf_corr, [("out_file", "in_file")]),


### PR DESCRIPTION
Closes #2614 and is related to https://github.com/nipreps/niworkflows/pull/843.

## Changes proposed in this pull request
- Feed `skip_vols` into confounds correlation plot. Since niworkflows is pinned to `master` in `pyproject.toml`, the new parameter from https://github.com/nipreps/niworkflows/pull/843 can be used without waiting for a niworkflows release.