### PR TITLE
FIX: Retrieve atlas ROIs at requested density

### DIFF
--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -641,8 +641,8 @@ The BOLD time-series were resampled onto the left/right-symmetric template
     ]
     atlases = smriprep_data.load_resource('atlases')
     select_surfaces.inputs.template_roi = [
-        str(atlases / 'L.atlasroi.32k_fs_LR.shape.gii'),
-        str(atlases / 'R.atlasroi.32k_fs_LR.shape.gii'),
+        str(atlases / f'L.atlasroi.{fslr_density}_fs_LR.shape.gii'),
+        str(atlases / f'R.atlasroi.{fslr_density}_fs_LR.shape.gii'),
     ]
 
     # RibbonVolumeToSurfaceMapping.sh


### PR DESCRIPTION
Fixes #3178. Depends on https://github.com/nipreps/smriprep/pull/405 to actually work, but can be merged separately.