### PR TITLE
Revert "MAINT: load reportlets interfaces from nireports rather than niworkflows"

### DIFF
--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -47,8 +47,8 @@ from nipype.interfaces.base import (
     traits,
 )
 from nipype.utils.filemanip import fname_presuffix
-from nireports.reportlets.modality.func import fMRIPlot
 from niworkflows.utils.timeseries import _cifti_timeseries, _nifti_timeseries
+from niworkflows.viz.plots import fMRIPlot
 
 LOGGER = logging.getLogger('nipype.interface')
 

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -39,7 +39,7 @@ from nipype.interfaces.base import (
     isdefined,
     traits,
 )
-from nireports.interfaces.reporting import base as nrb
+from niworkflows.interfaces.reportlets import base as nrb
 from smriprep.interfaces.freesurfer import ReconAll
 
 LOGGER = logging.getLogger('nipype.interface')

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -146,10 +146,6 @@ def init_bold_confs_wf(
         Mask of brain edge voxels
 
     """
-    from nireports.interfaces.nuisance import (
-        CompCorVariancePlot,
-        ConfoundsCorrelationPlot,
-    )
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.interfaces.confounds import ExpandModel, SpikeRegressors
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
@@ -158,6 +154,10 @@ def init_bold_confs_wf(
     from niworkflows.interfaces.nibabel import ApplyMask, Binarize
     from niworkflows.interfaces.patches import RobustACompCor as ACompCor
     from niworkflows.interfaces.patches import RobustTCompCor as TCompCor
+    from niworkflows.interfaces.plotting import (
+        CompCorVariancePlot,
+        ConfoundsCorrelationPlot,
+    )
     from niworkflows.interfaces.reportlets.masks import ROIsPlot
     from niworkflows.interfaces.utility import TSV2JSON, AddTSVHeader, DictMerge
 

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -31,6 +31,7 @@ from niworkflows.func.util import init_enhance_and_skullstrip_bold_wf
 from niworkflows.interfaces.header import ValidateImage
 from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 from niworkflows.interfaces.utility import KeySelect
+from niworkflows.utils.connections import listify
 from sdcflows.workflows.apply.correction import init_unwarp_wf
 from sdcflows.workflows.apply.registration import init_coeff2epi_wf
 

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -185,7 +185,7 @@ def init_func_fit_reports_wf(
         Template space and specifications
 
     """
-    from nireports.interfaces.reporting.base import (
+    from niworkflows.interfaces.reportlets.registration import (
         SimpleBeforeAfterRPT as SimpleBeforeAfter,
     )
     from sdcflows.interfaces.reportlets import FieldmapReportlet

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -168,10 +168,10 @@ def init_t2s_reporting_wf(name: str = 't2s_reporting_wf'):
         a before/after figure comparing the reference BOLD image and T2\* map
     """
     from nipype.pipeline import engine as pe
-    from nireports.interfaces.reporting.base import (
+    from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
+    from niworkflows.interfaces.reportlets.registration import (
         SimpleBeforeAfterRPT as SimpleBeforeAfter,
     )
-    from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 
     workflow = pe.Workflow(name=name)
 


### PR DESCRIPTION
Reverts nipreps/fmriprep#3176.

Looks like tests weren't passing for other reasons.