### PR TITLE
ENH: Allow --ignore fmap-jacobian to disable Jacobian determinant modulation during fieldmap correction

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -285,7 +285,7 @@ def _build_parser(**kwargs):
         action="store",
         nargs="+",
         default=[],
-        choices=["fieldmaps", "slicetiming", "sbref", "t2w", "flair"],
+        choices=["fieldmaps", "slicetiming", "sbref", "t2w", "flair", "fmap-jacobian"],
         help="Ignore selected aspects of the input dataset to disable corresponding "
         "parts of the workflow (a space delimited list)",
     )

--- a/fmriprep/workflows/bold/apply.py
+++ b/fmriprep/workflows/bold/apply.py
@@ -16,6 +16,7 @@ def init_bold_volumetric_resample_wf(
     *,
     metadata: dict,
     mem_gb: dict[str, float],
+    jacobian: bool,
     fieldmap_id: str | None = None,
     omp_nthreads: int = 1,
     name: str = 'bold_volumetric_resample_wf',
@@ -123,7 +124,7 @@ def init_bold_volumetric_resample_wf(
     boldref2target = pe.Node(niu.Merge(2), name='boldref2target', run_without_submitting=True)
     bold2target = pe.Node(niu.Merge(2), name='bold2target', run_without_submitting=True)
     resample = pe.Node(
-        ResampleSeries(),
+        ResampleSeries(jacobian=jacobian),
         name="resample",
         n_procs=omp_nthreads,
         mem_gb=mem_gb['resampled'],

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -380,6 +380,7 @@ configured with cubic B-spline interpolation.
         fieldmap_id=fieldmap_id if not multiecho else None,
         omp_nthreads=omp_nthreads,
         mem_gb=mem_gb,
+        jacobian='fmap-jacobian' not in config.workflow.ignore,
         name='bold_anat_wf',
     )
     bold_anat_wf.inputs.inputnode.resolution = "native"
@@ -437,6 +438,7 @@ configured with cubic B-spline interpolation.
             fieldmap_id=fieldmap_id if not multiecho else None,
             omp_nthreads=omp_nthreads,
             mem_gb=mem_gb,
+            jacobian='fmap-jacobian' not in config.workflow.ignore,
             name='bold_std_wf',
         )
         ds_bold_std_wf = init_ds_volumes_wf(
@@ -521,6 +523,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             fieldmap_id=fieldmap_id if not multiecho else None,
             omp_nthreads=omp_nthreads,
             mem_gb=mem_gb,
+            jacobian='fmap-jacobian' not in config.workflow.ignore,
             name='bold_MNI6_wf',
         )
 

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -838,7 +838,7 @@ def init_bold_native_wf(
 
     # Resample to boldref
     boldref_bold = pe.Node(
-        ResampleSeries(),
+        ResampleSeries(jacobian="fmap-jacobian" not in config.workflow.ignore),
         name="boldref_bold",
         n_procs=omp_nthreads,
         mem_gb=mem_gb["resampled"],


### PR DESCRIPTION
There is some indication (https://github.com/nipreps/sdcflows/issues/413) that fieldmap correction can lead to weird patches of intensity variation. This is almost certainly caused to modulation by the Jacobian determinant image, although the reason that this is not working as expected in these cases is unclear.

In any case, this allows the behavior to be disabled with `--ignore fmap-jacobian`.