### PR TITLE
TST: Update test to reflect new report generation behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,27 +648,6 @@ jobs:
                 --mem-mb 14336 --nthreads 4 -vv --debug compcor
       - run: *check_outputs
       - run:
-          name: Generate report with one artificial error
-          command: |
-            set -x
-            sudo mv /tmp/${DATASET}/fmriprep/sub-100185.html \
-                    /tmp/${DATASET}/fmriprep/sub-100185_noerror.html
-            UUID=$(grep uuid /tmp/${DATASET}/work/*/config.toml | cut -d\" -f 2 | tail -n 1)
-            mkdir -p /tmp/${DATASET}/fmriprep/sub-100185/log/$UUID/
-            cp /tmp/src/fmriprep/fmriprep/data/tests/crash_files/*.txt \
-                /tmp/${DATASET}/fmriprep/sub-100185/log/$UUID/
-            set +e
-            fmriprep-docker -i nipreps/fmriprep:latest \
-                -e FMRIPREP_DEV 1 --user $(id -u):$(id -g) \
-                --config $PWD/nipype.cfg -w /tmp/${DATASET}/work \
-                /tmp/data/${DATASET} /tmp/${DATASET}/fmriprep participant \
-                --fs-no-reconall --sloppy --write-graph \
-                --output-spaces MNI152NLin2009cAsym:res-2 anat func \
-                --reports-only --config-file /tmp/${DATASET}/work/${UUID}/config.toml -vv
-            RET=$?
-            set -e
-            [[ "$RET" -eq "0" ]]  # ensure report was generated successfully
-      - run:
           name: Clean working directory
           when: on_success
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -667,7 +667,7 @@ jobs:
                 --reports-only --config-file /tmp/${DATASET}/work/${UUID}/config.toml -vv
             RET=$?
             set -e
-            [[ "$RET" -eq "1" ]]
+            [[ "$RET" -eq "0" ]]  # ensure report was generated successfully
       - run:
           name: Clean working directory
           when: on_success

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -224,17 +224,14 @@ def main():
         write_bidsignore(config.execution.fmriprep_dir)
 
         if failed_reports:
-            config.loggers.cli.error(
-                "Report generation was not successful for the following participants : %s.",
-                ", ".join(failed_reports),
+            msg = (
+                'Report generation was not successful for the following participants '
+                f': {", ".join(failed_reports)}.'
             )
+            config.loggers.cli.error(msg)
+            if sentry_sdk is not None:
+                sentry_sdk.capture_message(msg, level="error")
 
-        if sentry_sdk is not None and failed_reports:
-            sentry_sdk.capture_message(
-                "Report generation was not successful for the following participants : %s.",
-                ", ".join(failed_reports),
-                level="error",
-            )
         sys.exit(int((errno + len(failed_reports)) > 0))
 
 


### PR DESCRIPTION
Closes #3209 

The exit code for `--reports-only` should be an indicator of report generation status, not whether or not errors were present in the workflow (those should be reported separately, at the time they are encountered during processing).