### PR TITLE
FIX: Support lists in bids filter file containing `null` or `*`

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -90,13 +90,24 @@ def _build_parser(**kwargs):
     def _drop_sub(value):
         return value[4:] if value.startswith("sub-") else value
 
-    def _filter_pybids_none_any(dct):
+    def _process_value(value):
         import bids
 
-        return {
-            k: bids.layout.Query.NONE if v is None else (bids.layout.Query.ANY if v == "*" else v)
-            for k, v in dct.items()
-        }
+        if value is None:
+            return bids.layout.Query.NONE
+        elif value == "*":
+            return bids.layout.Query.ANY
+        else:
+            return value
+
+    def _filter_pybids_none_any(dct):
+        d = {}
+        for k, v in dct.items():
+            if isinstance(v, list):
+                d[k] = [_process_value(val) for val in v]
+            else:
+                d[k] = _process_value(v)
+        return d
 
     def _bids_filter(value, parser):
         from json import JSONDecodeError, loads

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -493,12 +493,21 @@ class execution(_Config):
         if cls.bids_filters:
             from bids.layout import Query
 
+            def _process_value(value):
+                """Convert string with "Query" in it to Query object."""
+                if isinstance(value, list):
+                    return [_process_value(val) for val in value]
+                else:
+                    return (
+                        getattr(Query, value[7:-4])
+                        if not isinstance(value, Query) and "Query" in value
+                        else value
+                    )
+
             # unserialize pybids Query enum values
             for acq, filters in cls.bids_filters.items():
-                cls.bids_filters[acq] = {
-                    k: getattr(Query, v[7:-4]) if not isinstance(v, Query) and "Query" in v else v
-                    for k, v in filters.items()
-                }
+                for k, v in filters.items():
+                    cls.bids_filters[acq][k] = _process_value(v)
 
         if "all" in cls.debug:
             cls.debug = list(DEBUG_MODES)


### PR DESCRIPTION
Closes #3214.

## Changes proposed in this pull request

- Update action in CLI for `--bids-filter-file` parameter to loop through lists and check for `null` or `*`.
- Update `Config.bids_filters` in `config.py` to loop through lists and check for `Query.ANY` or `Query.NONE`.
