### PR TITLE
FIX: delete summary from functional report when separated by sessions

### DIFF
--- a/fmriprep/data/reports-spec-func.yml
+++ b/fmriprep/data/reports-spec-func.yml
@@ -1,8 +1,5 @@
 package: fmriprep
 sections:
-- name: Summary
-  reportlets:
-  - bids: {datatype: figures, desc: summary, suffix: T1w}
 - name: <em>B<sub>0</sub></em> field mapping
   ordering: session,acquisition,run,fmapid
   reportlets:


### PR DESCRIPTION
To avoid repeating the same summary many times when the reports are separated by sessions, remove the summary from the functional report template.