### PR TITLE
DOCKER: Restore mincinfo binary

### DIFF
--- a/docker/files/freesurfer7.3.2-exclude.txt
+++ b/docker/files/freesurfer7.3.2-exclude.txt
@@ -791,7 +791,6 @@ freesurfer/mni/bin/mincexpand
 freesurfer/mni/bin/mincextract
 freesurfer/mni/bin/mincheader
 freesurfer/mni/bin/minchistory
-freesurfer/mni/bin/mincinfo
 freesurfer/mni/bin/minclookup
 freesurfer/mni/bin/mincmakescalar
 freesurfer/mni/bin/mincmakevector


### PR DESCRIPTION
Reported in https://neurostars.org/t/fmriprepv23-freesurfer-recon-all-autorecon1-tailrach-transform-failing/28423, and I believe @jbwexler found it in the OpenNeuro runs.