### PR TITLE
FIX: Add datasink fill-in step to resampling level

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -372,6 +372,11 @@ configured with cubic B-spline interpolation.
         ])  # fmt:skip
 
     if config.workflow.level == "resampling":
+        # Fill-in datasinks of reportlets seen so far
+        for node in workflow.list_node_names():
+            if node.split('.')[-1].startswith('ds_report'):
+                workflow.get_node(node).inputs.base_directory = fmriprep_dir
+                workflow.get_node(node).inputs.source_file = bold_file
         return workflow
 
     # Resample to anatomical space


### PR DESCRIPTION
Closes #3253.

## Changes proposed in this pull request

- Copy code used to fill in `source_file` and `base_directory` fields for reportlet datasinks in `init_bold_wf` for the `full` level to the `resampling` level as well.
    - AFAICT, the only reportlets that should be generated by the resampling level are `ds_report_t2scomp` and `ds_report_t2star_hist`, so I could directly add these fields to those nodes, but this approach seems more robust.


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None
