### PR TITLE
ENH: Use BIDS URIs to track Sources in sidecars

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -225,7 +225,7 @@ def main():
         write_derivative_description(
             config.execution.bids_dir,
             config.execution.fmriprep_dir,
-            dataset_links=config.execution.dataset_links.items(),
+            dataset_links=config.execution.dataset_links,
         )
         write_bidsignore(config.execution.fmriprep_dir)
 

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -222,7 +222,11 @@ def main():
             config.execution.run_uuid,
             session_list=session_list,
         )
-        write_derivative_description(config.execution.bids_dir, config.execution.fmriprep_dir)
+        write_derivative_description(
+            config.execution.bids_dir,
+            config.execution.fmriprep_dir,
+            dataset_links=config.execution.dataset_links.items(),
+        )
         write_bidsignore(config.execution.fmriprep_dir)
 
         if failed_reports:

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -226,6 +226,8 @@ class _Config:
             if k in cls._paths:
                 if isinstance(v, list | tuple):
                     setattr(cls, k, [Path(val).absolute() for val in v])
+                elif isinstance(v, dict):
+                    setattr(cls, k, {key: Path(val).absolute() for key, val in v.items()})
                 else:
                     setattr(cls, k, Path(v).absolute())
             elif hasattr(cls, k):
@@ -251,6 +253,8 @@ class _Config:
             if k in cls._paths:
                 if isinstance(v, list | tuple):
                     v = [str(val) for val in v]
+                elif isinstance(v, dict):
+                    v = {key: str(val) for key, val in v.items()}
                 else:
                     v = str(v)
             if isinstance(v, SpatialReferences):
@@ -439,6 +443,8 @@ class execution(_Config):
     """Path to a working directory where intermediate results will be available."""
     write_graph = False
     """Write out the computational graph corresponding to the planned preprocessing."""
+    dataset_links = None
+    """A dictionary of dataset links to be used to track Sources in sidecars."""
 
     _layout = None
 
@@ -454,6 +460,7 @@ class execution(_Config):
         'output_dir',
         'templateflow_home',
         'work_dir',
+        'dataset_links',
     )
 
     @classmethod
@@ -517,6 +524,11 @@ class execution(_Config):
             for acq, filters in cls.bids_filters.items():
                 for k, v in filters.items():
                     cls.bids_filters[acq][k] = _process_value(v)
+
+        dataset_links = {'raw': cls.bids_dir}
+        for i_deriv, deriv_path in enumerate(cls.derivatives):
+            dataset_links[f'deriv-{i_deriv}'] = deriv_path
+        cls.dataset_links = dataset_links
 
         if 'all' in cls.debug:
             cls.debug = list(DEBUG_MODES)

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -443,7 +443,7 @@ class execution(_Config):
     """Path to a working directory where intermediate results will be available."""
     write_graph = False
     """Write out the computational graph corresponding to the planned preprocessing."""
-    dataset_links = None
+    dataset_links = {}
     """A dictionary of dataset links to be used to track Sources in sidecars."""
 
     _layout = None

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -20,8 +20,8 @@ class _BIDSURIInputSpec(TraitedSpec):
         mandatory=True,
         desc='Input imaging file(s)',
     )
-    dataset_links = traits.Dict()
-    out_dir = traits.Str()
+    dataset_links = traits.Dict(mandatory=True, desc='Dataset links')
+    out_dir = traits.Str(mandatory=True, desc='Output directory')
 
 
 class _BIDSURIOutputSpec(TraitedSpec):

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -3,14 +3,14 @@
 from pathlib import Path
 
 from bids.utils import listify
-from nipype.interfaces.base import SimpleInterface, TraitedSpec, traits
+from nipype.interfaces.base import DynamicTraitedSpec, SimpleInterface, TraitedSpec, traits
 from nipype.interfaces.io import add_traits
 from nipype.interfaces.utility.base import _ravel
 
 from ..utils.bids import _find_nearest_path
 
 
-class _BIDSURIInputSpec(TraitedSpec):
+class _BIDSURIInputSpec(DynamicTraitedSpec):
     dataset_links = traits.Dict(mandatory=True, desc='Dataset links')
     out_dir = traits.Str(mandatory=True, desc='Output directory')
 

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -1,8 +1,8 @@
 """BIDS-related interfaces."""
 
-from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, traits
-
 from pathlib import Path
+
+from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, traits
 
 from .. import config
 from ..utils.bids import _find_nearest_path

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -3,23 +3,13 @@
 from pathlib import Path
 
 from bids.utils import listify
-from nipype.interfaces.base import (
-    File,
-    InputMultiObject,
-    SimpleInterface,
-    TraitedSpec,
-    traits,
-)
+from nipype.interfaces.base import TraitedSpec, traits
+from nipype.interfaces.io import IOBase, add_traits
 
 from ..utils.bids import _find_nearest_path
 
 
 class _BIDSURIInputSpec(TraitedSpec):
-    in_files = InputMultiObject(
-        File(exists=True),
-        mandatory=True,
-        desc='Input imaging file(s)',
-    )
     dataset_links = traits.Dict(mandatory=True, desc='Dataset links')
     out_dir = traits.Str(mandatory=True, desc='Output directory')
 
@@ -31,14 +21,27 @@ class _BIDSURIOutputSpec(TraitedSpec):
     )
 
 
-class BIDSURI(SimpleInterface):
-    """Convert input filenames to BIDS URIs, based on links in the dataset."""
+class BIDSURI(IOBase):
+    """Convert input filenames to BIDS URIs, based on links in the dataset.
+
+    This interface can combine multiple lists of inputs.
+    """
 
     input_spec = _BIDSURIInputSpec
     output_spec = _BIDSURIOutputSpec
 
+    def __init__(self, numinputs=0, **inputs):
+        super().__init__(**inputs)
+        self._numinputs = numinputs
+        if numinputs >= 1:
+            input_names = [f'in{i + 1}' for i in range(numinputs)]
+        else:
+            input_names = []
+        add_traits(self.inputs, input_names)
+
     def _run_interface(self, runtime):
-        in_files = listify(self.inputs.in_files)
+        inputs = [getattr(self.inputs, f'in{i + 1}') for i in range(self._numinputs)]
+        in_files = listify(inputs)
         updated_keys = {f'bids:{k}:': Path(v) for k, v in self.inputs.dataset_links.items()}
         updated_keys['bids::'] = Path(self.inputs.out_dir)
         out = [_find_nearest_path(updated_keys, Path(f)) for f in in_files]

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -1,0 +1,48 @@
+"""BIDS-related interfaces."""
+
+from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, traits
+
+from pathlib import Path
+
+from .. import config
+from ..utils.bids import _find_nearest_path
+
+
+class _BIDSURIInputSpec(TraitedSpec):
+    in_file = traits.Either(
+        File(exists=False),
+        traits.List(File(exists=False)),
+        mandatory=True,
+        desc='Input imaging file(s)',
+    )
+
+
+class _BIDSURIOutputSpec(TraitedSpec):
+    uri = traits.Either(
+        traits.Str,
+        traits.List(traits.Str),
+        desc='BIDS URI(s) for file',
+    )
+
+
+class BIDSURI(SimpleInterface):
+    """Simple clipping interface that clips values to specified minimum/maximum
+
+    If no values are outside the bounds, nothing is done and the in_file is passed
+    as the out_file without copying.
+    """
+
+    input_spec = _BIDSURIInputSpec
+    output_spec = _BIDSURIOutputSpec
+
+    def _run_interface(self, runtime):
+        updated_keys = {f'bids:{k}:': v for k, v in config.execution.dataset_links.items()}
+        updated_keys['bids::'] = config.execution.fmriprep_dir
+        if isinstance(self.inputs.in_file, list):
+            uri = [_find_nearest_path(f, updated_keys) for f in self.inputs.in_file]
+        else:
+            uri = _find_nearest_path(updated_keys, Path(self.inputs.in_file))
+
+        self._results['uri'] = uri
+
+        return runtime

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from bids.utils import listify
 from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, traits
 
-from .. import config
 from ..utils.bids import _find_nearest_path
 
 
@@ -16,6 +15,8 @@ class _BIDSURIInputSpec(TraitedSpec):
         mandatory=True,
         desc='Input imaging file(s)',
     )
+    dataset_links = traits.Dict()
+    out_dir = traits.Str()
 
 
 class _BIDSURIOutputSpec(TraitedSpec):
@@ -37,8 +38,8 @@ class BIDSURI(SimpleInterface):
 
     def _run_interface(self, runtime):
         in_files = listify(self.inputs.in_files)
-        updated_keys = {f'bids:{k}:': v for k, v in config.execution.dataset_links.items()}
-        updated_keys['bids::'] = config.execution.fmriprep_dir
+        updated_keys = {f'bids:{k}:': v for k, v in self.inputs.dataset_links.items()}
+        updated_keys['bids::'] = self.inputs.out_dir
         out = [_find_nearest_path(updated_keys, Path(f)) for f in in_files]
         self._results['out'] = out
 

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 
 from bids.utils import listify
-from nipype.interfaces.base import TraitedSpec, traits
-from nipype.interfaces.io import IOBase, add_traits
+from nipype.interfaces.base import SimpleInterface, TraitedSpec, traits
+from nipype.interfaces.io import add_traits
 
 from ..utils.bids import _find_nearest_path
 
@@ -21,7 +21,7 @@ class _BIDSURIOutputSpec(TraitedSpec):
     )
 
 
-class BIDSURI(IOBase):
+class BIDSURI(SimpleInterface):
     """Convert input filenames to BIDS URIs, based on links in the dataset.
 
     This interface can combine multiple lists of inputs.

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -3,7 +3,13 @@
 from pathlib import Path
 
 from bids.utils import listify
-from nipype.interfaces.base import DynamicTraitedSpec, SimpleInterface, TraitedSpec, traits
+from nipype.interfaces.base import (
+    DynamicTraitedSpec,
+    SimpleInterface,
+    TraitedSpec,
+    isdefined,
+    traits,
+)
 from nipype.interfaces.io import add_traits
 from nipype.interfaces.utility.base import _ravel
 
@@ -44,8 +50,12 @@ class BIDSURI(SimpleInterface):
         inputs = [getattr(self.inputs, f'in{i + 1}') for i in range(self._numinputs)]
         in_files = listify(inputs)
         in_files = _ravel(in_files)
+        # Remove undefined inputs
+        in_files = [f for f in in_files if isdefined(f)]
+        # Convert the dataset links to BIDS URI prefixes
         updated_keys = {f'bids:{k}:': Path(v) for k, v in self.inputs.dataset_links.items()}
         updated_keys['bids::'] = Path(self.inputs.out_dir)
+        # Convert the paths to BIDS URIs
         out = [_find_nearest_path(updated_keys, f) for f in in_files]
         self._results['out'] = out
 

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from bids.utils import listify
 from nipype.interfaces.base import SimpleInterface, TraitedSpec, traits
 from nipype.interfaces.io import add_traits
+from nipype.interfaces.utility.base import _ravel
 
 from ..utils.bids import _find_nearest_path
 
@@ -42,9 +43,10 @@ class BIDSURI(SimpleInterface):
     def _run_interface(self, runtime):
         inputs = [getattr(self.inputs, f'in{i + 1}') for i in range(self._numinputs)]
         in_files = listify(inputs)
+        in_files = _ravel(in_files)
         updated_keys = {f'bids:{k}:': Path(v) for k, v in self.inputs.dataset_links.items()}
         updated_keys['bids::'] = Path(self.inputs.out_dir)
-        out = [_find_nearest_path(updated_keys, Path(f)) for f in in_files]
+        out = [_find_nearest_path(updated_keys, f) for f in in_files]
         self._results['out'] = out
 
         return runtime

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -39,7 +39,7 @@ class BIDSURI(SimpleInterface):
     def _run_interface(self, runtime):
         in_files = listify(self.inputs.in_files)
         updated_keys = {f'bids:{k}:': v for k, v in self.inputs.dataset_links.items()}
-        updated_keys['bids::'] = self.inputs.out_dir
+        updated_keys['bids::'] = Path(self.inputs.out_dir)
         out = [_find_nearest_path(updated_keys, Path(f)) for f in in_files]
         self._results['out'] = out
 

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -39,7 +39,7 @@ class BIDSURI(SimpleInterface):
         updated_keys = {f'bids:{k}:': v for k, v in config.execution.dataset_links.items()}
         updated_keys['bids::'] = config.execution.fmriprep_dir
         if isinstance(self.inputs.in_file, list):
-            uri = [_find_nearest_path(f, updated_keys) for f in self.inputs.in_file]
+            uri = [_find_nearest_path(updated_keys, Path(f)) for f in self.inputs.in_file]
         else:
             uri = _find_nearest_path(updated_keys, Path(self.inputs.in_file))
 

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -3,15 +3,20 @@
 from pathlib import Path
 
 from bids.utils import listify
-from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, traits
+from nipype.interfaces.base import (
+    File,
+    InputMultiObject,
+    SimpleInterface,
+    TraitedSpec,
+    traits,
+)
 
 from ..utils.bids import _find_nearest_path
 
 
 class _BIDSURIInputSpec(TraitedSpec):
-    in_files = traits.Either(
-        File(exists=False),
-        traits.List(File(exists=False)),
+    in_files = InputMultiObject(
+        File(exists=True),
         mandatory=True,
         desc='Input imaging file(s)',
     )

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -32,18 +32,14 @@ class _BIDSURIOutputSpec(TraitedSpec):
 
 
 class BIDSURI(SimpleInterface):
-    """Simple clipping interface that clips values to specified minimum/maximum
-
-    If no values are outside the bounds, nothing is done and the in_files is passed
-    as the out_file without copying.
-    """
+    """Convert input filenames to BIDS URIs, based on links in the dataset."""
 
     input_spec = _BIDSURIInputSpec
     output_spec = _BIDSURIOutputSpec
 
     def _run_interface(self, runtime):
         in_files = listify(self.inputs.in_files)
-        updated_keys = {f'bids:{k}:': v for k, v in self.inputs.dataset_links.items()}
+        updated_keys = {f'bids:{k}:': Path(v) for k, v in self.inputs.dataset_links.items()}
         updated_keys['bids::'] = Path(self.inputs.out_dir)
         out = [_find_nearest_path(updated_keys, Path(f)) for f in in_files]
         self._results['out'] = out

--- a/fmriprep/interfaces/tests/test_bids.py
+++ b/fmriprep/interfaces/tests/test_bids.py
@@ -1,0 +1,72 @@
+"""Tests for fmriprep.interfaces.bids."""
+
+
+def test_BIDSURI():
+    """Test the BIDSURI interface."""
+    from fmriprep.interfaces.bids import BIDSURI
+
+    dataset_links = {
+        'raw': '/data',
+        'deriv-0': '/data/derivatives/source-1',
+    }
+    out_dir = '/data/derivatives/fmriprep'
+
+    # A single element as a string
+    interface = BIDSURI(
+        numinputs=1,
+        dataset_links=dataset_links,
+        out_dir=out_dir,
+        in1='/data/sub-01/func/sub-01_task-rest_bold.nii.gz',
+    )
+    results = interface.run()
+    assert results.outputs.out == ['bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz']
+
+    # A single element as a list
+    interface = BIDSURI(
+        numinputs=1,
+        dataset_links=dataset_links,
+        out_dir=out_dir,
+        in1=['/data/sub-01/func/sub-01_task-rest_bold.nii.gz'],
+    )
+    results = interface.run()
+    assert results.outputs.out == ['bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz']
+
+    # Two inputs: a string and a list
+    interface = BIDSURI(
+        numinputs=2,
+        dataset_links=dataset_links,
+        out_dir=out_dir,
+        in1='/data/sub-01/func/sub-01_task-rest_bold.nii.gz',
+        in2=[
+            '/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz',
+            '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',
+        ],
+    )
+    results = interface.run()
+    assert results.outputs.out == [
+        'bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz',
+        'bids:deriv-0:sub-01/func/sub-01_task-rest_bold.nii.gz',
+        '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',  # No change
+    ]
+
+    # Two inputs as lists
+    interface = BIDSURI(
+        numinputs=2,
+        dataset_links=dataset_links,
+        out_dir=out_dir,
+        in1=[
+            '/data/sub-01/func/sub-01_task-rest_bold.nii.gz',
+            'bids:raw:sub-01/func/sub-01_task-rest_boldref.nii.gz',
+        ],
+        in2=[
+            '/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz',
+            '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',
+        ],
+    )
+    results = interface.run()
+    assert results.outputs.out == [
+        'bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz',
+        'bids:raw:sub-01/func/sub-01_task-rest_boldref.nii.gz',  # No change
+        'bids:deriv-0:sub-01/func/sub-01_task-rest_bold.nii.gz',
+        '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',  # No change
+    ]

--- a/fmriprep/interfaces/tests/test_bids.py
+++ b/fmriprep/interfaces/tests/test_bids.py
@@ -16,8 +16,8 @@ def test_BIDSURI():
         numinputs=1,
         dataset_links=dataset_links,
         out_dir=out_dir,
-        in1='/data/sub-01/func/sub-01_task-rest_bold.nii.gz',
     )
+    interface.inputs.in1 = '/data/sub-01/func/sub-01_task-rest_bold.nii.gz'
     results = interface.run()
     assert results.outputs.out == ['bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz']
 
@@ -26,8 +26,8 @@ def test_BIDSURI():
         numinputs=1,
         dataset_links=dataset_links,
         out_dir=out_dir,
-        in1=['/data/sub-01/func/sub-01_task-rest_bold.nii.gz'],
     )
+    interface.inputs.in1 = ['/data/sub-01/func/sub-01_task-rest_bold.nii.gz']
     results = interface.run()
     assert results.outputs.out == ['bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz']
 
@@ -36,12 +36,12 @@ def test_BIDSURI():
         numinputs=2,
         dataset_links=dataset_links,
         out_dir=out_dir,
-        in1='/data/sub-01/func/sub-01_task-rest_bold.nii.gz',
-        in2=[
-            '/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz',
-            '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',
-        ],
     )
+    interface.inputs.in1 = '/data/sub-01/func/sub-01_task-rest_bold.nii.gz'
+    interface.inputs.in2 = [
+        '/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz',
+        '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',
+    ]
     results = interface.run()
     assert results.outputs.out == [
         'bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz',
@@ -54,15 +54,15 @@ def test_BIDSURI():
         numinputs=2,
         dataset_links=dataset_links,
         out_dir=out_dir,
-        in1=[
-            '/data/sub-01/func/sub-01_task-rest_bold.nii.gz',
-            'bids:raw:sub-01/func/sub-01_task-rest_boldref.nii.gz',
-        ],
-        in2=[
-            '/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz',
-            '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',
-        ],
     )
+    interface.inputs.in1 = [
+        '/data/sub-01/func/sub-01_task-rest_bold.nii.gz',
+        'bids:raw:sub-01/func/sub-01_task-rest_boldref.nii.gz',
+    ]
+    interface.inputs.in2 = [
+        '/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz',
+        '/out/sub-01/func/sub-01_task-rest_bold.nii.gz',
+    ]
     results = interface.run()
     assert results.outputs.out == [
         'bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz',

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -146,7 +146,7 @@ def write_derivative_description(bids_dir, deriv_dir):
         desc['License'] = orig_desc['License']
 
     # Add DatasetLinks
-    desc['DatasetLinks'] = config.execution.dataset_links
+    desc['DatasetLinks'] = {k: str(v) for k, v in config.execution.dataset_links.items()}
 
     Path.write_text(deriv_dir / 'dataset_description.json', json.dumps(desc, indent=4))
 

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -402,10 +402,10 @@ def _find_nearest_path(path_dict, input_path):
     --------
     >>> from pathlib import Path
     >>> path_dict = {
-    >>>     'bids::': Path('/data/derivatives/fmriprep'),
-    >>>     'bids:raw:': Path('/data'),
-    >>>     'bids:deriv-0:': Path('/data/derivatives/source-1'),
-    >>> }
+    ...     'bids::': Path('/data/derivatives/fmriprep'),
+    ...     'bids:raw:': Path('/data'),
+    ...     'bids:deriv-0:': Path('/data/derivatives/source-1'),
+    ... }
     >>> input_path = Path('/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz')
     >>> find_nearest_path(path_dict, input_path)  # match to 'bids:deriv-0:'
     'bids:deriv-0:sub-01/func/sub-01_task-rest_bold.nii.gz'

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -348,15 +348,15 @@ def dismiss_echo(entities=None):
     return entities
 
 
-def convert_bids_uri(path):
+def _convert_bids_uri(in_files):
     """Convert a BIDS path to a URI.
 
     This uses the Config's dataset_links and fmriprep_dir as potential base paths.
 
     Parameters
     ----------
-    path : str or list of str
-        The path to convert to a URI. May be a list of Paths.
+    in_files : str or list of str
+        The path to convert to a URI. May be a list of paths.
 
     Returns
     -------
@@ -367,17 +367,17 @@ def convert_bids_uri(path):
     from pathlib import Path
 
     from fmriprep import config
-    from fmriprep.utils.bids import find_nearest_path
+    from fmriprep.utils.bids import _convert_bids_uri, _find_nearest_path
 
-    if isinstance(path, list):
-        return [convert_bids_uri(p) for p in path]
+    if isinstance(in_files, list):
+        return [_convert_bids_uri(p) for p in in_files]
 
     updated_keys = {f"bids:{k}:": v for k, v in config.execution.dataset_links.items()}
     updated_keys["bids::"] = config.execution.fmriprep_dir
-    return find_nearest_path(updated_keys, Path(path))
+    return _find_nearest_path(updated_keys, Path(in_files))
 
 
-def find_nearest_path(path_dict, input_path):
+def _find_nearest_path(path_dict, input_path):
     """Find the nearest relative path from an input path to a dictionary of paths.
 
     If ``input_path`` is not relative to any of the paths in ``path_dict``,

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -372,8 +372,8 @@ def _convert_bids_uri(in_files):
     if isinstance(in_files, list):
         return [_convert_bids_uri(p) for p in in_files]
 
-    updated_keys = {f"bids:{k}:": v for k, v in config.execution.dataset_links.items()}
-    updated_keys["bids::"] = config.execution.fmriprep_dir
+    updated_keys = {f'bids:{k}:': v for k, v in config.execution.dataset_links.items()}
+    updated_keys['bids::'] = config.execution.fmriprep_dir
     return _find_nearest_path(updated_keys, Path(in_files))
 
 
@@ -425,9 +425,8 @@ def _find_nearest_path(path_dict, input_path):
                 matching_path = relative_path
 
     if matching_path is None:
-        print("Warning: No matching path found. Defaulting to absolute path.")
         matching_path = input_path.absolute()
     else:
-        matching_path = f"{matching_key}{matching_path}"
+        matching_path = f'{matching_key}{matching_path}'
 
     return matching_path

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -383,6 +383,8 @@ def _find_nearest_path(path_dict, input_path):
     If ``input_path`` is not relative to any of the paths in ``path_dict``,
     the absolute path string is returned.
 
+    If ``input_path`` is already a BIDS-URI, then it will be returned unmodified.
+
     Parameters
     ----------
     path_dict : dict of (str, Path)
@@ -415,7 +417,14 @@ def _find_nearest_path(path_dict, input_path):
     >>> input_path = Path('/data/sub-01/func/sub-01_task-rest_bold.nii.gz')
     >>> _find_nearest_path(path_dict, input_path)  # match to 'bids:raw:'
     'bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz'
+    >>> input_path = 'bids::sub-01/func/sub-01_task-rest_bold.nii.gz'
+    >>> _find_nearest_path(path_dict, input_path)  # already a BIDS-URI
+    'bids::sub-01/func/sub-01_task-rest_bold.nii.gz'
     """
+    # Don't modify BIDS-URIs
+    if isinstance(input_path, str) and input_path.startswith('bids:'):
+        return input_path
+
     matching_path = None
     for key, path in path_dict.items():
         if input_path.is_relative_to(path):

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -425,7 +425,7 @@ def _find_nearest_path(path_dict, input_path):
                 matching_path = relative_path
 
     if matching_path is None:
-        matching_path = input_path.absolute()
+        matching_path = str(input_path.absolute())
     else:
         matching_path = f'{matching_key}{matching_path}'
 

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -97,7 +97,7 @@ def write_bidsignore(deriv_dir):
     ignore_file.write_text('\n'.join(bids_ignore) + '\n')
 
 
-def write_derivative_description(bids_dir, deriv_dir):
+def write_derivative_description(bids_dir, deriv_dir, dataset_links=None):
     from .. import __version__
 
     DOWNLOAD_URL = f'https://github.com/nipreps/fmriprep/archive/{__version__}.tar.gz'
@@ -146,7 +146,8 @@ def write_derivative_description(bids_dir, deriv_dir):
         desc['License'] = orig_desc['License']
 
     # Add DatasetLinks
-    desc['DatasetLinks'] = {k: str(v) for k, v in config.execution.dataset_links.items()}
+    if dataset_links:
+        desc['DatasetLinks'] = {k: str(v) for k, v in dataset_links.items()}
 
     Path.write_text(deriv_dir / 'dataset_description.json', json.dumps(desc, indent=4))
 
@@ -346,35 +347,6 @@ def dismiss_echo(entities=None):
         entities.append('echo')
 
     return entities
-
-
-def _convert_bids_uri(in_files):
-    """Convert a BIDS path to a URI.
-
-    This uses the Config's dataset_links and fmriprep_dir as potential base paths.
-
-    Parameters
-    ----------
-    in_files : str or list of str
-        The path to convert to a URI. May be a list of paths.
-
-    Returns
-    -------
-    str or list of str
-        The BIDS-URI of the input path.
-        If the input path is a list, the output is a list.
-    """
-    from pathlib import Path
-
-    from fmriprep import config
-    from fmriprep.utils.bids import _convert_bids_uri, _find_nearest_path
-
-    if isinstance(in_files, list):
-        return [_convert_bids_uri(p) for p in in_files]
-
-    updated_keys = {f'bids:{k}:': v for k, v in config.execution.dataset_links.items()}
-    updated_keys['bids::'] = config.execution.fmriprep_dir
-    return _find_nearest_path(updated_keys, Path(in_files))
 
 
 def _find_nearest_path(path_dict, input_path):

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -397,6 +397,7 @@ def _find_nearest_path(path_dict, input_path):
     if isinstance(input_path, str) and input_path.startswith('bids:'):
         return input_path
 
+    input_path = Path(input_path)
     matching_path = None
     for key, path in path_dict.items():
         if input_path.is_relative_to(path):

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -407,13 +407,13 @@ def _find_nearest_path(path_dict, input_path):
     ...     'bids:deriv-0:': Path('/data/derivatives/source-1'),
     ... }
     >>> input_path = Path('/data/derivatives/source-1/sub-01/func/sub-01_task-rest_bold.nii.gz')
-    >>> find_nearest_path(path_dict, input_path)  # match to 'bids:deriv-0:'
+    >>> _find_nearest_path(path_dict, input_path)  # match to 'bids:deriv-0:'
     'bids:deriv-0:sub-01/func/sub-01_task-rest_bold.nii.gz'
     >>> input_path = Path('/out/sub-01/func/sub-01_task-rest_bold.nii.gz')
-    >>> find_nearest_path(path_dict, input_path)  # no match- absolute path
+    >>> _find_nearest_path(path_dict, input_path)  # no match- absolute path
     '/out/sub-01/func/sub-01_task-rest_bold.nii.gz'
     >>> input_path = Path('/data/sub-01/func/sub-01_task-rest_bold.nii.gz')
-    >>> find_nearest_path(path_dict, input_path)  # match to 'bids:raw:'
+    >>> _find_nearest_path(path_dict, input_path)  # match to 'bids:raw:'
     'bids:raw:sub-01/func/sub-01_task-rest_bold.nii.gz'
     """
     matching_path = None

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -328,6 +328,8 @@ configured with cubic B-spline interpolation.
         workflow.connect([
             (bold_fit_wf, ds_bold_native_wf, [
                 ('outputnode.bold_mask', 'inputnode.bold_mask'),
+                ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
+                ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
             ]),
             (bold_native_wf, ds_bold_native_wf, [
                 ('outputnode.bold_native', 'inputnode.bold'),

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -399,7 +399,6 @@ def init_bold_fit_wf(
         )
         ds_hmc_boldref_wf.inputs.inputnode.source_files = [bold_file]
 
-        # fmt:off
         workflow.connect([
             (hmc_boldref_wf, hmcref_buffer, [
                 ('outputnode.bold_file', 'bold_file'),
@@ -411,9 +410,10 @@ def init_bold_fit_wf(
             (hmc_boldref_wf, func_fit_reports_wf, [
                 ('outputnode.validation_report', 'inputnode.validation_report'),
             ]),
-            (ds_hmc_boldref_wf, hmc_boldref_source_buffer, [('out_file', 'in_file')]),
-        ])
-        # fmt:on
+            (ds_hmc_boldref_wf, hmc_boldref_source_buffer, [
+                ('outputnode.boldref', 'in_file'),
+            ]),
+        ])  # fmt:skip
     else:
         config.loggers.workflow.info('Found HMC boldref - skipping Stage 1')
 
@@ -422,13 +422,11 @@ def init_bold_fit_wf(
 
         hmcref_buffer.inputs.boldref = precomputed['hmc_boldref']
 
-        # fmt:off
         workflow.connect([
             (validate_bold, hmcref_buffer, [('out_file', 'bold_file')]),
             (validate_bold, func_fit_reports_wf, [('out_report', 'inputnode.validation_report')]),
             (hmcref_buffer, hmc_boldref_source_buffer, [('boldref', 'in_file')]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
     # Stage 2: Estimate head motion
     if not hmc_xforms:
@@ -443,7 +441,6 @@ def init_bold_fit_wf(
         )
         ds_hmc_wf.inputs.inputnode.source_files = [bold_file]
 
-        # fmt:off
         workflow.connect([
             (hmcref_buffer, bold_hmc_wf, [
                 ('boldref', 'inputnode.raw_ref_image'),
@@ -455,8 +452,7 @@ def init_bold_fit_wf(
                 ('outputnode.movpar_file', 'movpar_file'),
                 ('outputnode.rmsd_file', 'rmsd_file'),
             ]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
     else:
         config.loggers.workflow.info('Found motion correction transforms - skipping Stage 2')
         hmc_buffer.inputs.hmc_xforms = hmc_xforms
@@ -477,7 +473,6 @@ def init_bold_fit_wf(
             name='ds_coreg_boldref_wf',
         )
 
-        # fmt:off
         workflow.connect([
             (hmcref_buffer, fmapref_buffer, [('boldref', 'boldref_files')]),
             (fmapref_buffer, enhance_boldref_wf, [('out', 'inputnode.in_file')]),
@@ -486,8 +481,7 @@ def init_bold_fit_wf(
             ]),
             (ds_coreg_boldref_wf, regref_buffer, [('outputnode.boldref', 'boldref')]),
             (fmapref_buffer, func_fit_reports_wf, [('out', 'inputnode.sdc_boldref')]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
         if fieldmap_id:
             fmap_select = pe.Node(

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -448,10 +448,10 @@ def init_bold_fit_wf(
             ]),
             (bold_hmc_wf, ds_hmc_wf, [('outputnode.xforms', 'inputnode.xforms')]),
             (bold_hmc_wf, hmc_buffer, [
-                ('outputnode.xforms', 'hmc_xforms'),
                 ('outputnode.movpar_file', 'movpar_file'),
                 ('outputnode.rmsd_file', 'rmsd_file'),
             ]),
+            (ds_hmc_wf, hmc_buffer, [('outputnode.xforms', 'hmc_xforms')]),
         ])  # fmt:skip
     else:
         config.loggers.workflow.info('Found motion correction transforms - skipping Stage 2')

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -453,10 +453,10 @@ def init_ds_boldref_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_file')]),
+        (inputnode, raw_sources, [('source_files', 'in_files')]),
         (inputnode, ds_boldref, [('boldref', 'in_file'),
                                  ('source_files', 'source_file')]),
-        (raw_sources, ds_boldref, [('uri', 'Sources')]),
+        (raw_sources, ds_boldref, [('out', 'Sources')]),
         (ds_boldref, outputnode, [('out_file', 'boldref')]),
     ])
     # fmt:on
@@ -498,10 +498,10 @@ def init_ds_registration_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_file')]),
+        (inputnode, raw_sources, [('source_files', 'in_files')]),
         (inputnode, ds_xform, [('xform', 'in_file'),
                                ('source_files', 'source_file')]),
-        (raw_sources, ds_xform, [('uri', 'Sources')]),
+        (raw_sources, ds_xform, [('out', 'Sources')]),
         (ds_xform, outputnode, [('out_file', 'xform')]),
     ])
     # fmt:on
@@ -541,10 +541,10 @@ def init_ds_hmc_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_file')]),
+        (inputnode, raw_sources, [('source_files', 'in_files')]),
         (inputnode, ds_xforms, [('xforms', 'in_file'),
                                 ('source_files', 'source_file')]),
-        (raw_sources, ds_xforms, [('uri', 'Sources')]),
+        (raw_sources, ds_xforms, [('out', 'Sources')]),
         (ds_xforms, outputnode, [('out_file', 'xforms')]),
     ])
     # fmt:on
@@ -580,7 +580,7 @@ def init_ds_bold_native_wf(
     )
 
     raw_sources = pe.Node(BIDSURI(), name='raw_sources')
-    workflow.connect(inputnode, 'source_files', raw_sources, 'in_file')
+    workflow.connect(inputnode, 'source_files', raw_sources, 'in_files')
 
     # Masks should be output if any other derivatives are output
     ds_bold_mask = pe.Node(
@@ -600,7 +600,7 @@ def init_ds_bold_native_wf(
             ('source_files', 'source_file'),
             ('bold_mask', 'in_file'),
         ]),
-        (raw_sources, ds_bold_mask, [('uri', 'Sources')]),
+        (raw_sources, ds_bold_mask, [('out', 'Sources')]),
     ])  # fmt:skip
 
     if bold_output:
@@ -648,7 +648,7 @@ def init_ds_bold_native_wf(
                 ('source_files', 'source_file'),
                 ('t2star', 'in_file'),
             ]),
-            (raw_sources, ds_t2star, [('uri', 'Sources')]),
+            (raw_sources, ds_t2star, [('out', 'Sources')]),
         ])  # fmt:skip
 
     if echo_output:
@@ -728,7 +728,7 @@ def init_ds_volumes_wf(
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_file')]),
+        (inputnode, raw_sources, [('source_files', 'in_files')]),
         (inputnode, boldref2target, [
             # Note that ANTs expects transforms in target-to-source order
             # Reverse this for nitransforms-based resamplers

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -713,7 +713,7 @@ def init_ds_volumes_wf(
     raw_sources = pe.Node(
         BIDSURI(
             dataset_links=config.execution.dataset_links,
-            out_dir=config.execution.fmriprep_dir,
+            out_dir=str(config.execution.fmriprep_dir.absolute()),
         ),
         name='raw_sources',
     )

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -595,6 +595,8 @@ def init_ds_bold_native_wf(
                 'bold_mask',
                 'bold_echos',
                 't2star',
+                'motion_xfm',
+                'boldref2fmap_xfm',
             ]
         ),
         name='inputnode',
@@ -602,13 +604,19 @@ def init_ds_bold_native_wf(
 
     raw_sources = pe.Node(
         BIDSURI(
-            numinputs=1,
+            numinputs=3,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.fmriprep_dir.absolute()),
         ),
         name='raw_sources',
     )
-    workflow.connect(inputnode, 'source_files', raw_sources, 'in1')
+    workflow.connect([
+        (inputnode, raw_sources, [
+            ('source_files', 'in1'),
+            ('motion_xfm', 'in2'),
+            ('boldref2fmap_xfm', 'in3'),
+        ]),
+    ])  # fmt:skip
 
     # Masks should be output if any other derivatives are output
     ds_bold_mask = pe.Node(

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -439,6 +439,7 @@ def init_ds_boldref_wf(
 
     raw_sources = pe.Node(
         BIDSURI(
+            numinputs=1,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.fmriprep_dir.absolute()),
         ),
@@ -459,7 +460,7 @@ def init_ds_boldref_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_files')]),
+        (inputnode, raw_sources, [('source_files', 'in1')]),
         (inputnode, ds_boldref, [('boldref', 'in_file'),
                                  ('source_files', 'source_file')]),
         (raw_sources, ds_boldref, [('out', 'Sources')]),
@@ -488,6 +489,7 @@ def init_ds_registration_wf(
 
     raw_sources = pe.Node(
         BIDSURI(
+            numinputs=1,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.fmriprep_dir.absolute()),
         ),
@@ -510,7 +512,7 @@ def init_ds_registration_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_files')]),
+        (inputnode, raw_sources, [('source_files', 'in1')]),
         (inputnode, ds_xform, [('xform', 'in_file'),
                                ('source_files', 'source_file')]),
         (raw_sources, ds_xform, [('out', 'Sources')]),
@@ -537,6 +539,7 @@ def init_ds_hmc_wf(
 
     raw_sources = pe.Node(
         BIDSURI(
+            numinputs=1,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.fmriprep_dir.absolute()),
         ),
@@ -559,7 +562,7 @@ def init_ds_hmc_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_files')]),
+        (inputnode, raw_sources, [('source_files', 'in1')]),
         (inputnode, ds_xforms, [('xforms', 'in_file'),
                                 ('source_files', 'source_file')]),
         (raw_sources, ds_xforms, [('out', 'Sources')]),
@@ -599,12 +602,13 @@ def init_ds_bold_native_wf(
 
     raw_sources = pe.Node(
         BIDSURI(
+            numinputs=1,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.fmriprep_dir.absolute()),
         ),
         name='raw_sources',
     )
-    workflow.connect(inputnode, 'source_files', raw_sources, 'in_files')
+    workflow.connect(inputnode, 'source_files', raw_sources, 'in1')
 
     # Masks should be output if any other derivatives are output
     ds_bold_mask = pe.Node(
@@ -736,6 +740,7 @@ def init_ds_volumes_wf(
 
     raw_sources = pe.Node(
         BIDSURI(
+            numinputs=1,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.fmriprep_dir.absolute()),
         ),
@@ -758,7 +763,7 @@ def init_ds_volumes_wf(
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
     workflow.connect([
-        (inputnode, raw_sources, [('source_files', 'in_files')]),
+        (inputnode, raw_sources, [('source_files', 'in1')]),
         (inputnode, boldref2target, [
             # Note that ANTs expects transforms in target-to-source order
             # Reverse this for nitransforms-based resamplers

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -437,7 +437,13 @@ def init_ds_boldref_wf(
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['boldref']), name='outputnode')
 
-    raw_sources = pe.Node(BIDSURI(), name='raw_sources')
+    raw_sources = pe.Node(
+        BIDSURI(
+            dataset_links=config.execution.dataset_links,
+            out_dir=str(config.execution.fmriprep_dir.absolute()),
+        ),
+        name='raw_sources',
+    )
 
     ds_boldref = pe.Node(
         DerivativesDataSink(
@@ -480,7 +486,13 @@ def init_ds_registration_wf(
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['xform']), name='outputnode')
 
-    raw_sources = pe.Node(BIDSURI(), name='raw_sources')
+    raw_sources = pe.Node(
+        BIDSURI(
+            dataset_links=config.execution.dataset_links,
+            out_dir=str(config.execution.fmriprep_dir.absolute()),
+        ),
+        name='raw_sources',
+    )
 
     ds_xform = pe.Node(
         DerivativesDataSink(
@@ -523,7 +535,13 @@ def init_ds_hmc_wf(
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['xforms']), name='outputnode')
 
-    raw_sources = pe.Node(BIDSURI(), name='raw_sources')
+    raw_sources = pe.Node(
+        BIDSURI(
+            dataset_links=config.execution.dataset_links,
+            out_dir=str(config.execution.fmriprep_dir.absolute()),
+        ),
+        name='raw_sources',
+    )
 
     ds_xforms = pe.Node(
         DerivativesDataSink(
@@ -579,7 +597,13 @@ def init_ds_bold_native_wf(
         name='inputnode',
     )
 
-    raw_sources = pe.Node(BIDSURI(), name='raw_sources')
+    raw_sources = pe.Node(
+        BIDSURI(
+            dataset_links=config.execution.dataset_links,
+            out_dir=str(config.execution.fmriprep_dir.absolute()),
+        ),
+        name='raw_sources',
+    )
     workflow.connect(inputnode, 'source_files', raw_sources, 'in_files')
 
     # Masks should be output if any other derivatives are output

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -29,12 +29,11 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 from niworkflows.utils.images import dseg_label
-from smriprep.workflows.outputs import _bids_relative
 
 from fmriprep import config
 from fmriprep.config import DEFAULT_MEMORY_MIN_GB
 from fmriprep.interfaces import DerivativesDataSink
-from fmriprep.utils.bids import dismiss_echo
+from fmriprep.utils.bids import _convert_bids_uri, dismiss_echo
 
 
 def prepare_timing_parameters(metadata: dict):
@@ -437,7 +436,7 @@ def init_ds_boldref_wf(
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['boldref']), name='outputnode')
 
-    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
+    raw_sources = pe.Node(niu.Function(function=_convert_bids_uri), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
     ds_boldref = pe.Node(
@@ -457,7 +456,7 @@ def init_ds_boldref_wf(
         (inputnode, raw_sources, [('source_files', 'in_files')]),
         (inputnode, ds_boldref, [('boldref', 'in_file'),
                                  ('source_files', 'source_file')]),
-        (raw_sources, ds_boldref, [('out', 'RawSources')]),
+        (raw_sources, ds_boldref, [('out', 'Sources')]),
         (ds_boldref, outputnode, [('out_file', 'boldref')]),
     ])
     # fmt:on
@@ -481,7 +480,7 @@ def init_ds_registration_wf(
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['xform']), name='outputnode')
 
-    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
+    raw_sources = pe.Node(niu.Function(function=_convert_bids_uri), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
     ds_xform = pe.Node(
@@ -503,7 +502,7 @@ def init_ds_registration_wf(
         (inputnode, raw_sources, [('source_files', 'in_files')]),
         (inputnode, ds_xform, [('xform', 'in_file'),
                                ('source_files', 'source_file')]),
-        (raw_sources, ds_xform, [('out', 'RawSources')]),
+        (raw_sources, ds_xform, [('out', 'Sources')]),
         (ds_xform, outputnode, [('out_file', 'xform')]),
     ])
     # fmt:on
@@ -525,7 +524,7 @@ def init_ds_hmc_wf(
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['xforms']), name='outputnode')
 
-    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
+    raw_sources = pe.Node(niu.Function(function=_convert_bids_uri), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
     ds_xforms = pe.Node(
@@ -547,7 +546,7 @@ def init_ds_hmc_wf(
         (inputnode, raw_sources, [('source_files', 'in_files')]),
         (inputnode, ds_xforms, [('xforms', 'in_file'),
                                 ('source_files', 'source_file')]),
-        (raw_sources, ds_xforms, [('out', 'RawSources')]),
+        (raw_sources, ds_xforms, [('out', 'Sources')]),
         (ds_xforms, outputnode, [('out_file', 'xforms')]),
     ])
     # fmt:on
@@ -582,7 +581,7 @@ def init_ds_bold_native_wf(
         name='inputnode',
     )
 
-    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
+    raw_sources = pe.Node(niu.Function(function=_convert_bids_uri), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
     workflow.connect(inputnode, 'source_files', raw_sources, 'in_files')
 
@@ -604,7 +603,7 @@ def init_ds_bold_native_wf(
             ('source_files', 'source_file'),
             ('bold_mask', 'in_file'),
         ]),
-        (raw_sources, ds_bold_mask, [('out', 'RawSources')]),
+        (raw_sources, ds_bold_mask, [('out', 'Sources')]),
     ])  # fmt:skip
 
     if bold_output:
@@ -652,7 +651,7 @@ def init_ds_bold_native_wf(
                 ('source_files', 'source_file'),
                 ('t2star', 'in_file'),
             ]),
-            (raw_sources, ds_t2star, [('out', 'RawSources')]),
+            (raw_sources, ds_t2star, [('out', 'Sources')]),
         ])  # fmt:skip
 
     if echo_output:
@@ -714,7 +713,7 @@ def init_ds_volumes_wf(
         name='inputnode',
     )
 
-    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
+    raw_sources = pe.Node(niu.Function(function=_convert_bids_uri), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
     boldref2target = pe.Node(niu.Merge(2), name='boldref2target')
 

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -710,7 +710,13 @@ def init_ds_volumes_wf(
         name='inputnode',
     )
 
-    raw_sources = pe.Node(BIDSURI(), name='raw_sources')
+    raw_sources = pe.Node(
+        BIDSURI(
+            dataset_links=config.execution.dataset_links,
+            out_dir=config.execution.fmriprep_dir,
+        ),
+        name='raw_sources',
+    )
     boldref2target = pe.Node(niu.Merge(2), name='boldref2target')
 
     # BOLD is pre-resampled


### PR DESCRIPTION
Closes #3252. This is just a first pass- it only modifies the RawSources for now. I can add the immediate Sources in another PR (this'll require a lot more effort).

## Changes proposed in this pull request

- Add `DatasetLinks` field to the `dataset_description.json`
    - The input dataset is called `raw`
    - Any other datasets supplied through `--derivatives` are automatically named `deriv-<index>`. We might want to support named derivatives at some point.
- Replace BIDS-relative paths in `RawSources` fields with BIDS-URIs.
- Change `RawSources` to `Sources` in the sidecar files, since `RawSources` is deprecated.

## Documentation that should be reviewed

I'll probably need to update the documentation, but haven't yet.