### PR TITLE
ENH: Support named derivative paths

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -68,6 +68,7 @@ def _build_parser(**kwargs):
             for i_kv, kv in enumerate(values):
                 if '=' not in kv:
                     k = f'deriv-{i_kv}'
+                    v = kv
                 else:
                     k, v = kv.split('=')
                 d[k] = Path(v)

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -236,7 +236,7 @@ def _build_parser(**kwargs):
         action=ToDict,
         metavar='PACKAGE=PATH',
         type=str,
-        nargs='*',
+        nargs='+',
         help=(
             'Search PATH(s) for pre-computed derivatives. '
             'These may be provided as named folders '

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -71,7 +71,7 @@ def _build_parser(**kwargs):
                     k = f'deriv-{i_kv}'
                 else:
                     k, v = kv.split('=')
-                d[k] = os.path.abspath(v)
+                d[k] = Path(v)
             setattr(namespace, self.dest, d)
 
     def _path_exists(path, parser):
@@ -236,7 +236,7 @@ def _build_parser(**kwargs):
         '--derivatives',
         action=ToDict,
         metavar='PACKAGE=PATH',
-        type=Path,
+        type=str,
         nargs='*',
         help=(
             'Search PATH(s) for pre-computed derivatives. '

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -63,6 +63,7 @@ def _build_parser(**kwargs):
             delattr(namespace, self.dest)
 
     class ToDict(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
             d = {}
             for spec in values:
                 try:
@@ -73,8 +74,9 @@ def _build_parser(**kwargs):
                     name = loc.name
 
                 if name in d:
-                    raise ValueError(f"Received duplicate derivative name: {name}")
-                d[k] = Path(v)
+                    raise ValueError(f'Received duplicate derivative name: {name}')
+
+                d[name] = loc
             setattr(namespace, self.dest, d)
 
     def _path_exists(path, parser):

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -22,7 +22,6 @@
 #
 """Parser."""
 
-import os
 import sys
 
 from .. import config

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -63,14 +63,17 @@ def _build_parser(**kwargs):
             delattr(namespace, self.dest)
 
     class ToDict(Action):
-        def __call__(self, parser, namespace, values, option_string=None):
             d = {}
-            for i_kv, kv in enumerate(values):
-                if '=' not in kv:
-                    k = f'deriv-{i_kv}'
-                    v = kv
-                else:
-                    k, v = kv.split('=')
+            for spec in values:
+                try:
+                    name, loc = spec.split('=')
+                    loc = Path(loc)
+                except ValueError:
+                    loc = Path(spec)
+                    name = loc.name
+
+                if name in d:
+                    raise ValueError(f"Received duplicate derivative name: {name}")
                 d[k] = Path(v)
             setattr(namespace, self.dest, d)
 

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -22,6 +22,7 @@
 #
 """Parser."""
 
+import os
 import sys
 
 from .. import config
@@ -61,6 +62,17 @@ def _build_parser(**kwargs):
                 msg += f' Please use `{new_opt}` instead.'
             print(msg, file=sys.stderr)
             delattr(namespace, self.dest)
+
+    class ToDict(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            d = {}
+            for i_kv, kv in enumerate(values):
+                if '=' not in kv:
+                    k = f'deriv-{i_kv}'
+                else:
+                    k, v = kv.split('=')
+                d[k] = os.path.abspath(v)
+            setattr(namespace, self.dest, d)
 
     def _path_exists(path, parser):
         """Ensure a given path exists."""
@@ -222,11 +234,15 @@ def _build_parser(**kwargs):
     g_bids.add_argument(
         '-d',
         '--derivatives',
-        action='store',
-        metavar='PATH',
+        action=ToDict,
+        metavar='PACKAGE=PATH',
         type=Path,
         nargs='*',
-        help='Search PATH(s) for pre-computed derivatives.',
+        help=(
+            'Search PATH(s) for pre-computed derivatives. '
+            'These may be provided as named folders '
+            '(e.g., `--derivatives smriprep=/path/to/smriprep`).'
+        ),
     )
     g_bids.add_argument(
         '--bids-database-dir',

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -228,3 +228,34 @@ def test_use_syn_sdc(tmp_path, args, expectation):
         assert opts.use_syn_sdc == expectation
 
     _reset_config()
+
+
+def test_derivatives(tmp_path):
+    """Check the correct parsing of the derivatives argument."""
+    bids_path = tmp_path / 'data'
+    out_path = tmp_path / 'out'
+    args = [str(bids_path), str(out_path), 'participant']
+    bids_path.mkdir()
+
+    parser = _build_parser()
+
+    # Providing --derivatives without a path should raise an error
+    temp_args = args + ['--derivatives']
+    with pytest.raises((SystemExit, ArgumentError)):
+        parser.parse_args(temp_args)
+    _reset_config()
+
+    # Providing --derivatives without names should automatically label them
+    temp_args = args + ['--derivatives', str(bids_path / 'derivatives/smriprep')]
+    opts = parser.parse_args(temp_args)
+    assert opts.derivatives == {'deriv-0': str(bids_path / 'derivatives/smriprep')}
+    _reset_config()
+
+    # Providing --derivatives with names should use them
+    temp_args = args + [
+        '--derivatives',
+        f'smriprep={str(bids_path / 'derivatives/smriprep')}',
+    ]
+    opts = parser.parse_args(temp_args)
+    assert opts.derivatives == {'smriprep': str(bids_path / 'derivatives/smriprep')}
+    _reset_config()

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -248,14 +248,25 @@ def test_derivatives(tmp_path):
     # Providing --derivatives without names should automatically label them
     temp_args = args + ['--derivatives', str(bids_path / 'derivatives/smriprep')]
     opts = parser.parse_args(temp_args)
-    assert opts.derivatives == {'deriv-0': str(bids_path / 'derivatives/smriprep')}
+    assert opts.derivatives == {'smriprep': bids_path / 'derivatives/smriprep'}
     _reset_config()
 
     # Providing --derivatives with names should use them
     temp_args = args + [
         '--derivatives',
-        f'smriprep={str(bids_path / "derivatives/smriprep")}',
+        f'anat={str(bids_path / "derivatives/smriprep")}',
     ]
     opts = parser.parse_args(temp_args)
-    assert opts.derivatives == {'smriprep': str(bids_path / 'derivatives/smriprep')}
+    assert opts.derivatives == {'anat': bids_path / 'derivatives/smriprep'}
+    _reset_config()
+
+    # Providing multiple unlabeled derivatives with the same name should raise an error
+    temp_args = args + [
+        '--derivatives',
+        str(bids_path / 'derivatives_01/smriprep'),
+        str(bids_path / 'derivatives_02/smriprep'),
+    ]
+    with pytest.raises(ValueError, match='Received duplicate derivative name'):
+        parser.parse_args(temp_args)
+
     _reset_config()

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -254,7 +254,7 @@ def test_derivatives(tmp_path):
     # Providing --derivatives with names should use them
     temp_args = args + [
         '--derivatives',
-        f'smriprep={str(bids_path / 'derivatives/smriprep')}',
+        f'smriprep={str(bids_path / "derivatives/smriprep")}',
     ]
     opts = parser.parse_args(temp_args)
     assert opts.derivatives == {'smriprep': str(bids_path / 'derivatives/smriprep')}

--- a/fmriprep/cli/workflow.py
+++ b/fmriprep/cli/workflow.py
@@ -116,7 +116,7 @@ def build_workflow(config_file, retval):
     ]
 
     if config.execution.derivatives:
-        init_msg += [f'Searching for derivatives: {config.execution.derivatives}.']
+        init_msg += [f'Searching for derivatives: {list(config.execution.derivatives.values())}.']
 
     if config.execution.fs_subjects_dir:
         init_msg += [f"Pre-run FreeSurfer's SUBJECTS_DIR: {config.execution.fs_subjects_dir}."]

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -380,7 +380,7 @@ class execution(_Config):
 
     bids_dir = None
     """An existing path to the dataset, which must be BIDS-compliant."""
-    derivatives = []
+    derivatives = {}
     """Path(s) to search for pre-computed derivatives"""
     bids_database_dir = None
     """Path to the directory containing SQLite database indices for the input BIDS dataset."""
@@ -526,8 +526,8 @@ class execution(_Config):
                     cls.bids_filters[acq][k] = _process_value(v)
 
         dataset_links = {'raw': cls.bids_dir}
-        for i_deriv, deriv_path in enumerate(cls.derivatives):
-            dataset_links[f'deriv-{i_deriv}'] = deriv_path
+        for deriv_name, deriv_path in cls.derivatives.items():
+            dataset_links[deriv_name] = deriv_path
         cls.dataset_links = dataset_links
 
         if 'all' in cls.debug:

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -249,7 +249,7 @@ It is released under the [CC0]\
 
         std_spaces = spaces.get_spaces(nonstandard=False, dim=(3,))
         std_spaces.append('fsnative')
-        for deriv_dir in config.execution.derivatives:
+        for deriv_dir in config.execution.derivatives.values():
             anatomical_cache.update(
                 collect_anat_derivatives(
                     derivatives_dir=deriv_dir,
@@ -653,7 +653,7 @@ tasks and sessions), the following preprocessing was performed.
 
             entities = extract_entities(bold_series)
 
-            for deriv_dir in config.execution.derivatives:
+            for deriv_dir in config.execution.derivatives.values():
                 functional_cache.update(
                     collect_derivatives(
                         derivatives_dir=deriv_dir,

--- a/wrapper/src/fmriprep_docker/__main__.py
+++ b/wrapper/src/fmriprep_docker/__main__.py
@@ -521,7 +521,7 @@ def main():
         unknown_args.append('--derivatives')
         for deriv, deriv_path in opts.derivatives.items():
             command.extend(['-v', '{}:/deriv/{}:ro'.format(deriv_path, deriv)])
-            unknown_args.append(f'{deriv}=/deriv/{deriv}')
+            unknown_args.append('{}=/deriv/{}'.format(deriv, deriv))
 
     if opts.work_dir:
         command.extend(['-v', ':'.join((opts.work_dir, '/scratch'))])

--- a/wrapper/src/fmriprep_docker/__main__.py
+++ b/wrapper/src/fmriprep_docker/__main__.py
@@ -521,7 +521,7 @@ def main():
         unknown_args.append('--derivatives')
         for deriv, deriv_path in opts.derivatives.items():
             command.extend(['-v', '{}:/deriv/{}:ro'.format(deriv_path, deriv)])
-            unknown_args.append('/deriv/{}'.format(deriv))
+            unknown_args.append(f'{deriv}=/deriv/{deriv}')
 
     if opts.work_dir:
         command.extend(['-v', ':'.join((opts.work_dir, '/scratch'))])

--- a/wrapper/src/fmriprep_docker/__main__.py
+++ b/wrapper/src/fmriprep_docker/__main__.py
@@ -521,7 +521,7 @@ def main():
         unknown_args.append('--derivatives')
         for deriv, deriv_path in opts.derivatives.items():
             command.extend(['-v', '{}:/deriv/{}:ro'.format(deriv_path, deriv)])
-            unknown_args.append('{}=/deriv/{}'.format(deriv, deriv))
+            unknown_args.append('/deriv/{}'.format(deriv))
 
     if opts.work_dir:
         command.extend(['-v', ':'.join((opts.work_dir, '/scratch'))])


### PR DESCRIPTION
Closes #3260.

## Changes proposed in this pull request

- Copy over `ToDict` action from fmriprep-docker over to the main CLI parser.
- Modify the Config to handle named derivative paths.
    - E.g., `--derivatives anat=/path/to/smriprep` --> `DatasetLinks = {'anat': '/path/to/smriprep'}`
- Infer derivative name from the folder name of the derivative path if it isn't labeled.
    - E.g., `--derivatives /path/to/smriprep` --> `DatasetLinks = {'smriprep': '/path/to/smriprep'}`