### PR TITLE
Add `--session-id` parameter and support longitudinal output structure

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -98,7 +98,7 @@ def _build_parser(**kwargs):
         return value[4:] if value.startswith('sub-') else value
 
     def _drop_ses(value):
-        return value[4:] if value.startswith("ses-") else value
+        return value[4:] if value.startswith('ses-') else value
 
     def _process_value(value):
         import bids
@@ -934,7 +934,7 @@ applied."""
 
 def compute_subworkflows(
     *,
-    layout: 'BIDSLayout',
+    layout: BIDSLayout,
     participant_ids: list,
     session_ids: list | None = None,
 ) -> list:

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -220,16 +220,10 @@ def main():
 
         from fmriprep.reports.core import generate_reports
 
-        # Generate reports phase
-        session_list = (
-            config.execution.get().get('bids_filters', {}).get('bold', {}).get('session')
-        )
-
         failed_reports = generate_reports(
-            config.execution.participant_label,
+            config.execution.unique_labels,
             config.execution.fmriprep_dir,
             config.execution.run_uuid,
-            session_list=session_list,
         )
         write_derivative_description(
             config.execution.bids_dir,

--- a/fmriprep/cli/workflow.py
+++ b/fmriprep/cli/workflow.py
@@ -35,7 +35,6 @@ a hard-limited memory-scope.
 def build_workflow(config_file, retval):
     """Create the Nipype Workflow that supports the whole execution graph."""
 
-    from niworkflows.utils.bids import collect_participants
     from niworkflows.utils.misc import check_valid_fs_license
 
     from fmriprep.reports.core import generate_reports

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -441,6 +441,8 @@ class execution(_Config):
     """Select a particular task from all available in the dataset."""
     templateflow_home = _templateflow_home
     """The root folder of the TemplateFlow client."""
+    unique_labels = None
+    """Combinations of subject + session identifiers to be preprocessed."""
     work_dir = Path('work').absolute()
     """Path to a working directory where intermediate results will be available."""
     write_graph = False
@@ -468,6 +470,12 @@ class execution(_Config):
     @classmethod
     def init(cls):
         """Create a new BIDS Layout accessible with :attr:`~execution.layout`."""
+        # Convert string literal None to NoneType
+        if cls.unique_labels:
+            cls.unique_labels = [
+                [sub, ses] if ses != 'None' else [sub, None] for sub, ses in cls.unique_labels
+            ]
+
         if cls.fs_license_file and Path(cls.fs_license_file).is_file():
             os.environ['FS_LICENSE'] = str(cls.fs_license_file)
 

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -433,6 +433,8 @@ class execution(_Config):
     """Only build the reports, based on the reportlets found in a cached working directory."""
     run_uuid = f"{strftime('%Y%m%d-%H%M%S')}_{uuid4()}"
     """Unique identifier of this particular run."""
+    session_id = None
+    """List of session identifiers that are to be preprocessed."""
     participant_label = None
     """List of participant identifiers that are to be preprocessed."""
     task_id = None

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -185,11 +185,7 @@ def init_single_subject_wf(
 
     from fmriprep.workflows.bold.base import init_bold_wf
 
-    name = (
-        f'sub_{subject_id}_ses_{session_id}_wf'
-        if session_id
-        else f'sub_{subject_id}_wf'
-    )
+    name = f'sub_{subject_id}_ses_{session_id}_wf' if session_id else f'sub_{subject_id}_wf'
 
     workflow = Workflow(name=name)
     workflow.__desc__ = f"""

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -186,9 +186,9 @@ def init_single_subject_wf(
     from fmriprep.workflows.bold.base import init_bold_wf
 
     name = (
-        f"sub_{subject_id}_ses_{session_id}_wf"
+        f'sub_{subject_id}_ses_{session_id}_wf'
         if session_id
-        else f"sub_{subject_id}_wf"
+        else f'sub_{subject_id}_wf'
     )
 
     workflow = Workflow(name=name)

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -46,7 +46,7 @@ from ..interfaces.reports import AboutSummary, SubjectSummary
 from ..utils.bids import dismiss_echo
 
 
-def init_fmriprep_wf():
+def init_fmriprep_wf(subworkflows_list):
     """
     Build *fMRIPrep*'s pipeline.
 
@@ -63,8 +63,15 @@ def init_fmriprep_wf():
 
             from fmriprep.workflows.tests import mock_config
             from fmriprep.workflows.base import init_fmriprep_wf
+
             with mock_config():
-                wf = init_fmriprep_wf()
+                wf = init_fmriprep_wf([('01', '01')])
+
+    Parameters
+    ----------
+    subworkflows_list: :obj:`list` of :obj:`tuple`
+        A list of the subworkflows to create.
+        Each subject session is run as an individual workflow.
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
@@ -90,12 +97,21 @@ def init_fmriprep_wf():
         if config.execution.fs_subjects_dir is not None:
             fsdir.inputs.subjects_dir = str(config.execution.fs_subjects_dir.absolute())
 
-    for subject_id in config.execution.participant_label:
-        single_subject_wf = init_single_subject_wf(subject_id)
-
-        single_subject_wf.config['execution']['crashdump_dir'] = str(
-            config.execution.fmriprep_dir / f'sub-{subject_id}' / 'log' / config.execution.run_uuid
+    for subject_id, session_id in subworkflows_list:
+        single_subject_wf = init_single_subject_wf(
+            subject_id,
+            session_id=session_id,
         )
+
+        bids_level = [f'sub-{subject_id}']
+        if session_id:
+            bids_level.append(f'ses-{session_id}')
+
+        log_dir = (
+            config.execution.nibabies_dir.joinpath(*bids_level) / 'log' / config.execution.run_uuid
+        )
+
+        single_subject_wf.config['execution']['crashdump_dir'] = str(log_dir)
         for node in single_subject_wf._get_all_nodes():
             node.config = deepcopy(single_subject_wf.config)
         if freesurfer:
@@ -104,16 +120,16 @@ def init_fmriprep_wf():
             fmriprep_wf.add_nodes([single_subject_wf])
 
         # Dump a copy of the config file into the log directory
-        log_dir = (
-            config.execution.fmriprep_dir / f'sub-{subject_id}' / 'log' / config.execution.run_uuid
-        )
         log_dir.mkdir(exist_ok=True, parents=True)
         config.to_filename(log_dir / 'fmriprep.toml')
 
     return fmriprep_wf
 
 
-def init_single_subject_wf(subject_id: str):
+def init_single_subject_wf(
+    subject_id: str,
+    session_id: str | None = None,
+):
     """
     Organize the preprocessing pipeline for a single subject.
 
@@ -138,6 +154,8 @@ def init_single_subject_wf(subject_id: str):
     ----------
     subject_id : :obj:`str`
         Subject label for this single-subject workflow.
+    session_id : :obj:`str` or None
+        Session identifier.
 
     Inputs
     ------
@@ -167,7 +185,13 @@ def init_single_subject_wf(subject_id: str):
 
     from fmriprep.workflows.bold.base import init_bold_wf
 
-    workflow = Workflow(name=f'sub_{subject_id}_wf')
+    name = (
+        f"sub_{subject_id}_ses_{session_id}_wf"
+        if session_id
+        else f"sub_{subject_id}_wf"
+    )
+
+    workflow = Workflow(name=name)
     workflow.__desc__ = f"""
 Results included in this manuscript come from preprocessing
 performed using *fMRIPrep* {config.environment.version}
@@ -202,6 +226,7 @@ It is released under the [CC0]\
     subject_data = collect_data(
         config.execution.layout,
         subject_id,
+        session_id=session_id,
         task=config.execution.task_id,
         echo=config.execution.echo_idx,
         bids_filters=config.execution.bids_filters,
@@ -254,6 +279,7 @@ It is released under the [CC0]\
                 collect_anat_derivatives(
                     derivatives_dir=deriv_dir,
                     subject_id=subject_id,
+                    session_id=session_id,
                     std_spaces=std_spaces,
                 )
             )


### PR DESCRIPTION
Closes nipreps/smriprep#429. I've only just started on this, and it won't deal with lingering longitudinal issues, such as:

1. Writing out session-level HTML reports to the subject's session folder.
    - Not sure how I feel about this one TBH.
2. Writing out session-level figures to the subject's session folder (see https://github.com/nipreps/nibabies/issues/350).
3. Running FreeSurfer on a session-wise basis (see https://github.com/nipreps/nibabies/issues/288).

## Changes proposed in this pull request

- Add `--session-id` command line parameter.
- Copy over longitudinal organization code from Nibabies.
    - In order to collect session-wise anatomical derivatives, we need to either add a `session_id` parameter to `smriprep.utils.bids.collect_derivatives()` or adopt Nibabies' `nibabies.utils.bids.Derivatives` class. Which is better?
