### PR TITLE
[FIX] Add "double" type to allowed DisplacementFieldTransform

### DIFF
--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -71,8 +71,10 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
     transform2 = h['TransformGroup']['2']
 
     # Confirm these transformations are applicable
-    if transform2['TransformType'][:][0] not in (b'DisplacementFieldTransform_float_3_3',
-                                                 b'DisplacementFieldTransform_double_3_3'):
+    if transform2['TransformType'][:][0] not in (
+        b'DisplacementFieldTransform_float_3_3',
+        b'DisplacementFieldTransform_double_3_3'
+    ):
         msg = 'Unknown transform type [2]\n'
         for i in h['TransformGroup'].keys():
             msg += f'[{i}]: {h["TransformGroup"][i]["TransformType"][:][0]}\n'

--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -71,7 +71,7 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
     transform2 = h['TransformGroup']['2']
 
     # Confirm these transformations are applicable
-    if transform2['TransformType'][:][0] not in (b'DisplacementFieldTransform_float_3_3', 
+    if transform2['TransformType'][:][0] not in (b'DisplacementFieldTransform_float_3_3',
                                                  b'DisplacementFieldTransform_double_3_3'):
         msg = 'Unknown transform type [2]\n'
         for i in h['TransformGroup'].keys():

--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -73,7 +73,7 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
     # Confirm these transformations are applicable
     if transform2['TransformType'][:][0] not in (
         b'DisplacementFieldTransform_float_3_3',
-        b'DisplacementFieldTransform_double_3_3'
+        b'DisplacementFieldTransform_double_3_3',
     ):
         msg = 'Unknown transform type [2]\n'
         for i in h['TransformGroup'].keys():

--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -71,7 +71,8 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
     transform2 = h['TransformGroup']['2']
 
     # Confirm these transformations are applicable
-    if transform2['TransformType'][:][0] not in (b'DisplacementFieldTransform_float_3_3', b'DisplacementFieldTransform_double_3_3'):
+    if transform2['TransformType'][:][0] not in (b'DisplacementFieldTransform_float_3_3', 
+                                                 b'DisplacementFieldTransform_double_3_3'):
         msg = 'Unknown transform type [2]\n'
         for i in h['TransformGroup'].keys():
             msg += f'[{i}]: {h["TransformGroup"][i]["TransformType"][:][0]}\n'

--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -71,7 +71,7 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
     transform2 = h['TransformGroup']['2']
 
     # Confirm these transformations are applicable
-    if transform2['TransformType'][:][0] != b'DisplacementFieldTransform_float_3_3':
+    if transform2['TransformType'][:][0] not in (b'DisplacementFieldTransform_float_3_3', b'DisplacementFieldTransform_double_3_3'):
         msg = 'Unknown transform type [2]\n'
         for i in h['TransformGroup'].keys():
             msg += f'[{i}]: {h["TransformGroup"][i]["TransformType"][:][0]}\n'


### PR DESCRIPTION
The ANTs utility `CompositeTransformUtil --assemble` outputs its displacement field as 'DisplacementFieldTransform_double_3_3', but utils/transform/load_ants_h5 throws an error unless it is 'DisplacementFieldTransform_float_3_3'. Presumably this is just a check to make sure it is a displacement field. The code after this check works fine for "double".

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
Just changing `!= b'DisplacementFieldTransform_float_3_3'` to `not in (b'DisplacementFieldTransform_float_3_3', b'DisplacementFieldTransform_float_3_3')`

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
