### PR TITLE
FIX: Write out boldref-space brain mask with minimal level

### DIFF
--- a/.circleci/ds005_fasttrack_outputs.txt
+++ b/.circleci/ds005_fasttrack_outputs.txt
@@ -23,6 +23,8 @@ sub-01/anat/sub-01_hemi-R_desc-reg_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-coreg_boldref.json
@@ -41,6 +43,8 @@ sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.fun
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.func.gii
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -43,6 +43,8 @@ sub-01/anat/sub-01_label-CSF_probseg.nii.gz
 sub-01/anat/sub-01_label-GM_probseg.nii.gz
 sub-01/anat/sub-01_label-WM_probseg.nii.gz
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-coreg_boldref.json
@@ -61,6 +63,8 @@ sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.fun
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.func.gii
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/.circleci/ds005_partial_fasttrack_outputs.txt
+++ b/.circleci/ds005_partial_fasttrack_outputs.txt
@@ -51,6 +51,8 @@ sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-magnitude_fieldmap.nii.gz
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.json
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.nii.gz
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -73,6 +73,8 @@ sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-magnitude_fieldmap.nii.gz
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.json
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.nii.gz
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -474,7 +474,6 @@ def init_bold_fit_wf(
             name='ds_coreg_boldref_wf',
         )
         ds_boldmask_wf = init_ds_boldmask_wf(
-            bids_root=layout.root,
             output_dir=config.execution.fmriprep_dir,
             desc='brain',
             name='ds_boldmask_wf',


### PR DESCRIPTION
Closes #3290.

## Changes proposed in this pull request

- Create `init_ds_boldmask_wf` workflow. This might be overkill.
- Write out the boldref-space brain mask in `init_bold_fit_wf`.
- Update expected outputs.
