### PR TITLE
FIX: Write out boldref-space brain mask with minimal level

### DIFF
--- a/.circleci/ds005_fasttrack_outputs.txt
+++ b/.circleci/ds005_fasttrack_outputs.txt
@@ -23,6 +23,8 @@ sub-01/anat/sub-01_hemi-R_desc-reg_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-coreg_boldref.json
@@ -41,6 +43,8 @@ sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.fun
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.func.gii
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -43,6 +43,8 @@ sub-01/anat/sub-01_label-CSF_probseg.nii.gz
 sub-01/anat/sub-01_label-GM_probseg.nii.gz
 sub-01/anat/sub-01_label-WM_probseg.nii.gz
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-coreg_boldref.json
@@ -61,6 +63,8 @@ sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.fun
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsaverage5_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.func.gii
 sub-01/func/sub-01_task-mixedgamblestask_run-01_hemi-R_space-fsnative_bold.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/.circleci/ds005_partial_fasttrack_outputs.txt
+++ b/.circleci/ds005_partial_fasttrack_outputs.txt
@@ -51,6 +51,8 @@ sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-magnitude_fieldmap.nii.gz
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.json
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.nii.gz
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -73,6 +73,8 @@ sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-magnitude_fieldmap.nii.gz
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.json
 sub-01/fmap/sub-01_run-02_fmapid-auto00000_desc-preproc_fieldmap.nii.gz
 sub-01/func
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.json
+sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-brain_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_timeseries.tsv
 sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-coreg_boldref.json

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -47,6 +47,7 @@ from ...utils.misc import estimate_bold_mem_usage
 # BOLD workflows
 from .hmc import init_bold_hmc_wf
 from .outputs import (
+    init_ds_boldmask_wf,
     init_ds_boldref_wf,
     init_ds_hmc_wf,
     init_ds_registration_wf,
@@ -467,6 +468,12 @@ def init_bold_fit_wf(
             desc='coreg',
             name='ds_coreg_boldref_wf',
         )
+        ds_boldmask_wf = init_ds_boldmask_wf(
+            bids_root=layout.root,
+            output_dir=config.execution.fmriprep_dir,
+            desc='brain',
+            name='ds_boldmask_wf',
+        )
 
         # fmt:off
         workflow.connect([
@@ -474,6 +481,7 @@ def init_bold_fit_wf(
             (fmapref_buffer, enhance_boldref_wf, [("out", "inputnode.in_file")]),
             (fmapref_buffer, ds_coreg_boldref_wf, [("out", "inputnode.source_files")]),
             (ds_coreg_boldref_wf, regref_buffer, [("outputnode.boldref", "boldref")]),
+            (ds_boldmask_wf, regref_buffer, [('outputnode.boldmask', 'boldmask')]),
             (fmapref_buffer, func_fit_reports_wf, [("out", "inputnode.sdc_boldref")]),
         ])
         # fmt:on
@@ -557,8 +565,8 @@ def init_bold_fit_wf(
                 (unwarp_wf, ds_coreg_boldref_wf, [
                     ('outputnode.corrected', 'inputnode.boldref'),
                 ]),
-                (unwarp_wf, regref_buffer, [
-                    ('outputnode.corrected_mask', 'boldmask'),
+                (unwarp_wf, ds_boldmask_wf, [
+                    ('outputnode.corrected_mask', 'inputnode.boldmask'),
                 ]),
                 (fmap_select, func_fit_reports_wf, [("fmap_ref", "inputnode.fmap_ref")]),
                 (fmap_select, summary, [("sdc_method", "distortion_correction")]),
@@ -574,8 +582,8 @@ def init_bold_fit_wf(
                 (enhance_boldref_wf, ds_coreg_boldref_wf, [
                     ('outputnode.bias_corrected_file', 'inputnode.boldref'),
                 ]),
-                (enhance_boldref_wf, regref_buffer, [
-                    ('outputnode.mask_file', 'boldmask'),
+                (enhance_boldref_wf, ds_boldmask_wf, [
+                    ('outputnode.mask_file', 'inputnode.boldmask'),
                 ]),
             ])
             # fmt:on


### PR DESCRIPTION
Closes #3290.

Changes proposed in this pull request
- Create init_ds_boldmask_wf workflow. This might be overkill.
- Write out the boldref-space brain mask in init_bold_fit_wf.
- Update expected outputs.
