### PR TITLE
FIX: Ensure shape matches template during resampling

### DIFF
--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -71,9 +71,10 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
 
     fixed_params = transform2['TransformFixedParameters'][:]
 
-    shape = tuple(fixed_params[:3].astype(int)[::-1])
-    warp = h['TransformGroup']['2']['TransformParameters'][:]
-    warp = warp.reshape((*shape, 3)).transpose(2, 1, 0, 3)
+    shape = tuple(fixed_params[:3].astype(int))
+    # ITK stores warps in Fortran-order, where the vector components change fastest
+    # Nitransforms expects 3 volumes, not a volume of three-vectors, so transpose
+    warp = np.reshape(transform2['TransformParameters'], (3, *shape), order='F').transpose(1, 2, 3, 0)
     warp *= np.array([-1, -1, 1])
 
     warp_affine = np.eye(4)

--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -71,6 +71,16 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
 
     fixed_params = transform2['TransformFixedParameters'][:]
 
+    spacing = fixed_params[6:9]
+    direction = fixed_params[9:]
+
+    # Supported spacing
+    if not np.array_equal(spacing, np.array([1.0, 1.0, 1.0])):
+        raise ValueError(f'Unexpected spacing: {spacing}')
+
+    if not np.array_equal(direction, np.diag([-1, -1, -1])):
+        raise ValueError(f'Asymmetric direction matrix: {direction}')
+
     shape = tuple(fixed_params[:3].astype(int))
     # ITK stores warps in Fortran-order, where the vector components change fastest
     # Nitransforms expects 3 volumes, not a volume of three-vectors, so transpose

--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -72,13 +72,13 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
     fixed_params = transform2['TransformFixedParameters'][:]
 
     spacing = fixed_params[6:9]
-    direction = fixed_params[9:]
+    direction = fixed_params[9:].reshape((3, 3))
 
     # Supported spacing
     if not np.array_equal(spacing, np.array([1.0, 1.0, 1.0])):
         raise ValueError(f'Unexpected spacing: {spacing}')
 
-    if not np.array_equal(direction, np.diag([-1, -1, -1])):
+    if not np.array_equal(direction, direction.T):
         raise ValueError(f'Asymmetric direction matrix: {direction}')
 
     shape = tuple(fixed_params[:3].astype(int))

--- a/fmriprep/utils/transforms.py
+++ b/fmriprep/utils/transforms.py
@@ -74,7 +74,11 @@ def load_ants_h5(filename: Path) -> nt.base.TransformBase:
     shape = tuple(fixed_params[:3].astype(int))
     # ITK stores warps in Fortran-order, where the vector components change fastest
     # Nitransforms expects 3 volumes, not a volume of three-vectors, so transpose
-    warp = np.reshape(transform2['TransformParameters'], (3, *shape), order='F').transpose(1, 2, 3, 0)
+    warp = np.reshape(
+        transform2['TransformParameters'],
+        (3, *shape),
+        order='F',
+    ).transpose(1, 2, 3, 0)
     warp *= np.array([-1, -1, 1])
 
     warp_affine = np.eye(4)


### PR DESCRIPTION
The reverse of the TransformFixedParameters should match the template dimensions.

This fell through the cracks because the templates tested (MNI152 variants) all have the same X and Z dimensions. Only when testing on a template with distinct values for shape did this become evident.

Additionally, this removes any `FIXED_PARAMS` checks, as that is template specific and more useful for debugging the initial implementation.