### PR TITLE
MNT: Pin libitk 5.3 and note dependencies

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -12,6 +12,8 @@ dependencies:
   - mkl-service=2.4.0
   # git-annex for templateflow users with DataLad superdatasets
   - git-annex=*=alldep*
+  # ANTs is linked against libitk 5.3 but does not pin the version
+  - libitk=5.3
   # Base scientific python stack; required by FSL, so pinned here
   - numpy=1.26
   - scipy=1.11


### PR DESCRIPTION
libitk 5.4 was being installed, while ANTs is built against libitk 5.3.