### PR TITLE
ENH: Add appropriate titles to HTML reports

### DIFF
--- a/fmriprep/data/reports-spec-anat.yml
+++ b/fmriprep/data/reports-spec-anat.yml
@@ -1,4 +1,5 @@
 package: fmriprep
+title: Anatomical report for participant '{subject}' - fMRIPrep
 sections:
 - name: Summary
   reportlets:

--- a/fmriprep/data/reports-spec-func.yml
+++ b/fmriprep/data/reports-spec-func.yml
@@ -1,4 +1,5 @@
 package: fmriprep
+title: Functional report for participant '{subject}', session '{session}' - fMRIPrep
 sections:
 - name: <em>B<sub>0</sub></em> field mapping
   ordering: session,acquisition,run,fmapid

--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -1,4 +1,5 @@
 package: fmriprep
+title: Visual report for participant '{subject}' - fMRIPrep
 sections:
 - name: Summary
   reportlets:


### PR DESCRIPTION
Noticed that nireports injects its own title, because we aren't adding ours:

![image](https://github.com/nipreps/fmriprep/assets/83442/bad4ff13-1f54-42ef-a8e7-bdf1accc3719)
