### PR TITLE
FIX: Validate and summarize multi-volume sbrefs

### DIFF
--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -465,6 +465,14 @@ def init_bold_fit_wf(
 
         # Select initial boldref, enhance contrast, and generate mask
         fmapref_buffer.inputs.sbref_files = sbref_files
+        if sbref_files and nb.load(sbref_files[0]).ndim > 3:
+            raw_sbref_wf = init_raw_boldref_wf(
+                name='raw_sbref_wf',
+                bold_file=sbref_files[0],
+                multiecho=len(sbref_files) > 1,
+            )
+            workflow.connect(raw_sbref_wf, 'outputnode.boldref', fmapref_buffer, 'sbref_files')
+
         enhance_boldref_wf = init_enhance_and_skullstrip_bold_wf(omp_nthreads=omp_nthreads)
 
         ds_coreg_boldref_wf = init_ds_boldref_wf(

--- a/fmriprep/workflows/bold/tests/test_base.py
+++ b/fmriprep/workflows/bold/tests/test_base.py
@@ -56,15 +56,18 @@ def test_bold_wf(
         bold_series = [
             str(bids_root / 'sub-01' / 'func' / 'sub-01_task-rest_run-1_bold.nii.gz'),
         ]
+        sbref = str(bids_root / 'sub-01' / 'func' / 'sub-01_task-rest_run-1_sbref.nii.gz')
     elif task == 'nback':
         bold_series = [
             str(bids_root / 'sub-01' / 'func' / f'sub-01_task-nback_echo-{i}_bold.nii.gz')
             for i in range(1, 4)
         ]
+        sbref = str(bids_root / 'sub-01' / 'func' / 'sub-01_task-nback_echo-1_sbref.nii.gz')
 
     # The workflow will attempt to read file headers
     for path in bold_series:
         img.to_filename(path)
+    img.to_filename(sbref)
 
     with mock_config(bids_dir=bids_root):
         config.workflow.bold2anat_init = bold2anat_init

--- a/fmriprep/workflows/bold/tests/test_fit.py
+++ b/fmriprep/workflows/bold/tests/test_fit.py
@@ -89,15 +89,19 @@ def test_bold_fit_precomputes(
         bold_series = [
             str(bids_root / 'sub-01' / 'func' / 'sub-01_task-rest_run-1_bold.nii.gz'),
         ]
+        sbref = str(bids_root / 'sub-01' / 'func' / 'sub-01_task-rest_run-1_sbref.nii.gz')
     elif task == 'nback':
         bold_series = [
             str(bids_root / 'sub-01' / 'func' / f'sub-01_task-nback_echo-{i}_bold.nii.gz')
             for i in range(1, 4)
         ]
+        sbref = str(bids_root / 'sub-01' / 'func' / 'sub-01_task-nback_echo-1_sbref.nii.gz')
 
     # The workflow will attempt to read file headers
     for path in bold_series:
         img.to_filename(path)
+    # Single volume sbref; multi-volume tested in test_base
+    img.slicer[:, :, :, 0].to_filename(sbref)
 
     dummy_nifti = str(tmp_path / 'dummy.nii')
     dummy_affine = str(tmp_path / 'dummy.txt')


### PR DESCRIPTION
## Changes proposed in this pull request

~~Not backportable as-is, although the change is very small. To backport into 24.0.x, we could check whether `sbref_files[0]` is 4D, and fall back to the existing code if not.~~

This only modifies the workflow in a known-breaking case. Safe for bug-fix releases.

Closes #3319.


## Documentation that should be reviewed