### PR TITLE
DOC: Read html_baseurl from RTD environment, if available

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+  apt_packages:
+    - graphviz
+  jobs:
+    post_checkout:
+      - git fetch --unshallow
+
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,8 @@ from github_link import make_linkcode_resolve
 
 # -- General configuration ------------------------------------------------
 
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = "1.5.3"
 


### PR DESCRIPTION
Following the advice of https://about.readthedocs.com/blog/2024/07/addons-by-default/.

Starting on the LTS, since there's still a chance a new release would come out.