### PR TITLE
RF: Replace `config.execution.fmriprep_dir` uses in BIDSURI calls with `output_dir` parameter

### DIFF
--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -441,7 +441,7 @@ def init_ds_boldref_wf(
         BIDSURI(
             numinputs=1,
             dataset_links=config.execution.dataset_links,
-            out_dir=str(config.execution.fmriprep_dir.absolute()),
+            out_dir=str(output_dir),
         ),
         name='sources',
     )
@@ -490,7 +490,7 @@ def init_ds_boldmask_wf(
         BIDSURI(
             numinputs=1,
             dataset_links=config.execution.dataset_links,
-            out_dir=str(config.execution.fmriprep_dir.absolute()),
+            out_dir=str(output_dir),
         ),
         name='sources',
     )
@@ -540,7 +540,7 @@ def init_ds_registration_wf(
         BIDSURI(
             numinputs=1,
             dataset_links=config.execution.dataset_links,
-            out_dir=str(config.execution.fmriprep_dir.absolute()),
+            out_dir=str(output_dir),
         ),
         name='sources',
     )
@@ -590,7 +590,7 @@ def init_ds_hmc_wf(
         BIDSURI(
             numinputs=1,
             dataset_links=config.execution.dataset_links,
-            out_dir=str(config.execution.fmriprep_dir.absolute()),
+            out_dir=str(output_dir),
         ),
         name='sources',
     )
@@ -655,7 +655,7 @@ def init_ds_bold_native_wf(
         BIDSURI(
             numinputs=3,
             dataset_links=config.execution.dataset_links,
-            out_dir=str(config.execution.fmriprep_dir.absolute()),
+            out_dir=str(output_dir),
         ),
         name='sources',
     )
@@ -783,7 +783,7 @@ def init_ds_volumes_wf(
         BIDSURI(
             numinputs=6,
             dataset_links=config.execution.dataset_links,
-            out_dir=str(config.execution.fmriprep_dir.absolute()),
+            out_dir=str(output_dir),
         ),
         name='sources',
     )

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -148,7 +148,7 @@ The BOLD time-series were resampled onto the following surfaces
         BIDSURI(
             numinputs=1,
             dataset_links=config.execution.dataset_links,
-            out_dir=str(config.execution.fmriprep_dir.absolute()),
+            out_dir=str(output_dir),
         ),
         name='surfs_sources',
     )


### PR DESCRIPTION
Closes #3337.

## Changes proposed in this pull request

- Use `output_dir` function argument for `BIDSURI` objects instead of the `config.execution.fmriprep_dir` field. This will let other preps (e.g., ASLPrep) use these workflow functions without having to mock up `fmriprep_dir` fields in their config objects.