### PR TITLE
CI: Build docker images in GHA, store cache inline and push to GHCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ _check_skip_job: &check_skip_job
     cd /tmp/src/fmriprep
     COMMIT_MSG="$(git show -s --format=%s)"
     DOCBUILD="$(echo ${COMMIT_MSG} | grep -i -E '^docs?(\(\w+\))?:')"
+    SKIP_ALL="$(echo ${COMMIT_MSG} | grep -i -E '\[skipcircle\]')"
     SKIP_PYTEST="$(echo ${COMMIT_MSG} | grep -i -E '\[skip[ _]?tests\]')"
     SKIP_DS005="$(echo ${COMMIT_MSG} | grep -i -E '\[skip[ _]?ds005\]' )"
     SKIP_DS054="$(echo ${COMMIT_MSG} | grep -i -E '\[skip[ _]?ds054\]' )"
@@ -61,6 +62,9 @@ _check_skip_job: &check_skip_job
       exit 0
     elif [[ -n "$DOCSBUILD" ]]; then  # always try to skip docs builds
       echo "Only docs build"
+      circleci step halt
+    elif [ -n "$SKIP_ALL" ]; then
+      echo "Skipping all!"
       circleci step halt
     elif [ -n "$CHECK_PYTEST" -a -n "$SKIP_PYTEST" ]; then
       echo "Skipping pytest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker build
 on:
   workflow_dispatch:
   push:
-    branches: [ "master", "main", "maint/*", "ci/gha-docker-build" ]
+    branches: [ "master", "main", "maint/*", "gha-docker-build" ]
     tags: "*"
   pull_request:
     branches: [ "master", "main", "maint/*" ]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,10 @@ name: Docker build
 on:
   workflow_dispatch:
   push:
-    branches: [ "master", "maint/*", "ci/gha-docker-build" ]
+    branches: [ "master", "main", "maint/*", "ci/gha-docker-build" ]
     tags: "*"
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "main", "maint/*" ]
 
 env:
   REGISTRY: ghcr.io
@@ -40,12 +40,18 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        id: build-and-push
         uses: docker/build-push-action@v4
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
-          cache-to: inline
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ env.TARGET_BRANCH }}
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ github.ref_name }}
+          cache-to: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ github.ref_name }},mode=max
+        env:
+          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,9 +8,14 @@ on:
   pull_request:
     branches: [ "master", "main", "maint/*" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FORCE_COLOR: true
 
 jobs:
   build-container:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,11 +52,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ env.TARGET_BRANCH }}
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ github.ref_name }}
-          cache-to: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ github.ref_name }},mode=max
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TARGET_BRANCH }}
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags[0] }}
+          cache-to: type=inline
         env:
           TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,14 +25,14 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,12 +40,12 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker build
 on:
   workflow_dispatch:
   push:
-    branches: [ "master", "maint/*" ]
+    branches: [ "master", "maint/*", "ci/gha-docker-build" ]
     tags: "*"
   pull_request:
     branches: [ "master" ]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Docker build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "master", "maint/*" ]
+    tags: "*"
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          cache-to: inline


### PR DESCRIPTION
This PR is a potential model for nipreps using GHA to build Docker images. The latest build (from a previous commit's cache) took 2 minutes, including checkout, build and push. If the cache needs rebuilding, it's <10 minutes. This is a vast improvement from Circle all on it's own.

I will make a separate PR to start triggering Circle builds from GHA after build. I would like to get to a model of:

```mermaid
graph LR;
  subgraph GitHub;
    test & build
  end
  subgraph Circle
    build --> ds005 & ds054 & ds210
  end
  subgraph gh2["GitHub"]
    test & ds005 & ds054 & ds210 --> deploy
  end
```

Where Circle runs anything where we want inspectable artifacts and nothing else. For SDCflows, it would be tests again, but with artifact saving turned on.