### PR TITLE
CI: Fetch tags and 200 commits to support describe

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 200
+          fetch-tags: true
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,10 @@ ARG BASE_IMAGE=ubuntu:jammy-20240125
 #
 # Build wheel
 #
-FROM python:slim AS src
-RUN pip install build
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git
+FROM ghcr.io/astral-sh/uv:python3.12-alpine AS src
+RUN apk add git
 COPY . /src
-RUN python -m build /src
+RUN uvx --from build pyproject-build --installer uv -w /src
 
 #
 # Download stages


### PR DESCRIPTION
This tests the behavior of PRs with the docker build. It should reuse the `ghcr.io/nipreps/fmriprep:master` cache and create `ghcr.io/nipreps/fmriprep:pull-3381` or similar.

It also checks out enough history to properly create a version string.