### PR TITLE
Install c3d through conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,12 +86,6 @@ RUN mkdir /opt/workbench && \
     rm -rf /opt/workbench/libs_linux64_software_opengl /opt/workbench/plugins_linux64 && \
     strip --remove-section=.note.ABI-tag /opt/workbench/libs_linux64/libQt5Core.so.5
 
-# Convert3d 1.4.0
-FROM downloader AS c3d
-RUN mkdir /opt/convert3d && \
-    curl -fsSL --retry 5 https://sourceforge.net/projects/c3d/files/c3d/Experimental/c3d-1.4.0-Linux-gcc64.tar.gz/download \
-    | tar -xz -C /opt/convert3d --strip-components 1
-
 # Micromamba
 FROM downloader AS micromamba
 
@@ -181,7 +175,6 @@ RUN apt-get update -qq \
 COPY --from=freesurfer /opt/freesurfer /opt/freesurfer
 COPY --from=afni /opt/afni-latest /opt/afni-latest
 COPY --from=workbench /opt/workbench /opt/workbench
-COPY --from=c3d /opt/convert3d/bin/c3d_affine_tool /usr/bin/c3d_affine_tool
 
 # Simulate SetUpFreeSurfer.sh
 ENV OS="Linux" \

--- a/env.yml
+++ b/env.yml
@@ -27,6 +27,8 @@ dependencies:
   - pandoc=3.1
   # Workflow dependencies: ANTs
   - ants=2.5
+  # Workflow dependencies: Convert3d
+  - convert3d=1.4
   # Workflow dependencies: FSL (versions pinned in 6.0.7.13)
   - fsl-bet2=2111.8
   - fsl-flirt=2111.2


### PR DESCRIPTION
The entire package (14MB) is smaller than the statically linked c3d_affine_tool (116MB).