### PR TITLE
FIX: Ensure fieldmap is resampled correctly in report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,10 +12,11 @@ Bug fix release in the 24.1.x series.
 Precomputed functional derivatives were not being correcly detected,
 and a couple fixes for rare issues.
 
-  * FIX: Remove checks for unit zooms and symmetric rotations in template warp (#3376)
-  * FIX: Stop excluding FS minc_modify_header used during fallback registration (#3372)
-  * FIX: Repair search for precomputed bold references (#3370)
-  * FIX: Repair search for precomputed transforms (#3369)
+* FIX: Remove checks for unit zooms and symmetric rotations in template warp (#3376)
+* FIX: Stop excluding FS minc_modify_header used during fallback registration (#3372)
+* FIX: Repair search for precomputed bold references (#3370)
+* FIX: Repair search for precomputed transforms (#3369)
+
 
 24.1.0 (September 16, 2024)
 ===========================
@@ -23,12 +24,13 @@ New feature release in the 24.1.x series.
 
 Handling of gradient echo fieldmaps is improved.
 
-  * FIX: Select volumetric dseg.tsv from recent TemplateFlow releases (#3257)
-  * RF: Adapt to less T1w-centric smriprep (#3333)
-  * RF: Use acres over vendored data loader (#3323)
-  * DOC: Add benchmark page (#3312)
-  * MAINT: Move to tox to simplify test/CI setup (#3326)
-  * CI: Fix expected outputs for fieldmaps (#3321)
+* FIX: Select volumetric dseg.tsv from recent TemplateFlow releases (#3257)
+* RF: Adapt to less T1w-centric smriprep (#3333)
+* RF: Use acres over vendored data loader (#3323)
+* DOC: Add benchmark page (#3312)
+* MAINT: Move to tox to simplify test/CI setup (#3326)
+* CI: Fix expected outputs for fieldmaps (#3321)
+
 
 24.0.1 (July 16, 2024)
 ======================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+24.1.2 (To be determined)
+=========================
+Bug fix release in the 24.1.x series.
+
+* FIX: Ensure fieldmap is resampled correctly in report (#3387)
+
+
 24.1.1 (October 10, 2024)
 =========================
 Bug fix release in the 24.1.x series.

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -316,6 +316,18 @@ def init_func_fit_reports_wf(
             mem_gb=1,
         )
 
+        fmap_boldref = pe.Node(
+            ApplyTransforms(
+                dimension=3,
+                default_value=0,
+                float=True,
+                invert_transform_flags=[True],
+                interpolation='LanczosWindowedSinc',
+            ),
+            name='fmap_boldref',
+            mem_gb=1,
+        )
+
         # SDC1
         sdcreg_report = pe.Node(
             FieldmapReportlet(
@@ -323,7 +335,7 @@ def init_func_fit_reports_wf(
                 moving_label='Fieldmap reference',
                 show='both',
             ),
-            name='sdecreg_report',
+            name='sdcreg_report',
             mem_gb=0.1,
         )
 
@@ -360,19 +372,23 @@ def init_func_fit_reports_wf(
             name='ds_sdc_report',
         )
 
-        # fmt:off
         workflow.connect([
             (inputnode, fmapref_boldref, [
                 ('fmap_ref', 'input_image'),
                 ('coreg_boldref', 'reference_image'),
                 ('boldref2fmap_xfm', 'transforms'),
             ]),
+            (inputnode, fmap_boldref, [
+                ('fieldmap', 'input_image'),
+                ('coreg_boldref', 'reference_image'),
+                ('boldref2fmap_xfm', 'transforms'),
+            ]),
             (inputnode, sdcreg_report, [
                 ('sdc_boldref', 'reference'),
-                ('fieldmap', 'fieldmap'),
                 ('bold_mask', 'mask'),
             ]),
             (fmapref_boldref, sdcreg_report, [('output_image', 'moving')]),
+            (fmap_boldref, sdcreg_report, [('output_image', 'fieldmap')]),
             (inputnode, ds_sdcreg_report, [('source_file', 'source_file')]),
             (sdcreg_report, ds_sdcreg_report, [('out_report', 'in_file')]),
             (inputnode, sdc_report, [
@@ -382,8 +398,7 @@ def init_func_fit_reports_wf(
             (boldref_wm, sdc_report, [('output_image', 'wm_seg')]),
             (inputnode, ds_sdc_report, [('source_file', 'source_file')]),
             (sdc_report, ds_sdc_report, [('out_report', 'in_file')]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
     # EPI-T1 registration
     # Resample T1w image onto EPI-space


### PR DESCRIPTION
While attempting to reproduce a bug report, I ran across a crash. Fieldmaps are always in RAS, while the BOLD references and masks are in the space of the original BOLD. In the case of ds000221, that's LSP. The reportlet assumes all input images are in the same space, and so can fail if the field-of-view is not a cube (and would be bad otherwise).

I was unable to reproduce the reported bug, but it's possible it was confused for this. For searchability's sake, the error was:

```
2024-10-21 12:21:37,963 [CRITICAL] fMRIPrep failed: Traceback (most recent call last):
  File "/home/chris/mambaforge/envs/fmriprep/lib/python3.11/site-packages/nipype/pipeline/plugins/multiproc.py", line 67, in run_node
    result["result"] = node.run(updatehash=updatehash)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chris/mambaforge/envs/fmriprep/lib/python3.11/site-packages/nipype/pipeline/engine/nodes.py", line 527, in run
    result = self._run_interface(execute=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chris/mambaforge/envs/fmriprep/lib/python3.11/site-packages/nipype/pipeline/engine/nodes.py", line 645, in _run_interface
    return self._run_command(execute)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chris/mambaforge/envs/fmriprep/lib/python3.11/site-packages/nipype/pipeline/engine/nodes.py", line 771, in _run_command
    raise NodeExecutionError(msg)
nipype.pipeline.engine.nodes.NodeExecutionError: Exception raised while executing Node sdecreg_report.

Traceback:
        Traceback (most recent call last):
          File "/home/chris/mambaforge/envs/fmriprep/lib/python3.11/site-packages/nipype/interfaces/base/core.py", line 398, in run
            runtime = self._post_run_hook(runtime)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/chris/mambaforge/envs/fmriprep/lib/python3.11/site-packages/nipype/interfaces/mixins/reporting.py", line 50, in _post_run_hook
            self._generate_report()
          File "/home/chris/Projects/nipreps/sdcflows/sdcflows/interfaces/reportlets.py", line 103, in _generate_report
            abs(np.percentile(fmapdata[maskdata], 99.8)),
                              ~~~~~~~~^^^^^^^^^^
        IndexError: boolean index did not match indexed array along dimension 1; dimension is 88 but corresponding boolean dimension is 64
```

I'm calling this a bug-fix because the workflow change occurred in a non-critical path (reports) and there is no risk of pollution from an existing working directory.