### PR TITLE
fix: Use removeprefix instead of lstrip or ternary operator

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -105,9 +105,6 @@ def _build_parser(**kwargs):
         units = value[len(digits) :] or 'M'
         return int(digits) * scale[units[0]]
 
-    def _drop_sub(value):
-        return value[4:] if value.startswith('sub-') else value
-
     def _process_value(value):
         import bids
 
@@ -205,7 +202,7 @@ def _build_parser(**kwargs):
         '--participant_label',
         action='store',
         nargs='+',
-        type=_drop_sub,
+        type=lambda label: label.removeprefix('sub-'),
         help='A space delimited list of participant identifiers or a single '
         'identifier (the sub- prefix can be removed)',
     )

--- a/fmriprep/reports/core.py
+++ b/fmriprep/reports/core.py
@@ -79,6 +79,7 @@ def generate_reports(
 
     errors = []
     for subject_label in subject_list:
+        subject_label = subject_label.removeprefix('sub-')
         # The number of sessions is intentionally not based on session_list but
         # on the total number of sessions, because I want the final derivatives
         # folder to be the same whether sessions were run one at a time or all-together.
@@ -95,7 +96,7 @@ def generate_reports(
         else:
             # Beyond a threshold, we separate the anatomical report from the functional.
             bootstrap_file = data.load('reports-spec-anat.yml')
-            html_report = f'sub-{subject_label.lstrip("sub-")}_anat.html'
+            html_report = f'sub-{subject_label}_anat.html'
 
         report_error = run_reports(
             output_dir,
@@ -121,12 +122,11 @@ def generate_reports(
                     subject=subject_label, **filters
                 )
 
-            # Drop ses- prefixes
-            session_list = [ses[4:] if ses.startswith('ses-') else ses for ses in session_list]
+            session_list = [ses.removeprefix('ses-') for ses in session_list]
 
             for session_label in session_list:
                 bootstrap_file = data.load('reports-spec-func.yml')
-                html_report = f'sub-{subject_label.lstrip("sub-")}_ses-{session_label}_func.html'
+                html_report = f'sub-{subject_label}_ses-{session_label}_func.html'
 
                 report_error = run_reports(
                     output_dir,

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -217,7 +217,7 @@ def validate_input_dir(exec_env, bids_dir, participant_label, need_T1w=True):
     # Limit validation only to data from requested participants
     if participant_label:
         all_subs = {s.name[4:] for s in bids_dir.glob('sub-*')}
-        selected_subs = {s[4:] if s.startswith('sub-') else s for s in participant_label}
+        selected_subs = {s.removeprefix('sub-') for s in participant_label}
         bad_labels = selected_subs.difference(all_subs)
         if bad_labels:
             error_msg = (


### PR DESCRIPTION
We had some `.lstrip()`s that should be `removeprefix()` as well as some pre-`removeprefix()` hacks of the form `s[len(prefix):] if s.startswith(prefix) else s`.