### PR TITLE
fix: Calculate bold mask and dummy scans in transform-only runs

### DIFF
--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -53,7 +53,7 @@ from .outputs import (
     init_ds_registration_wf,
     init_func_fit_reports_wf,
 )
-from .reference import init_raw_boldref_wf
+from .reference import init_raw_boldref_wf, init_validation_and_dummies_wf
 from .registration import init_bold_reg_wf
 from .stc import init_bold_stc_wf
 from .t2s import init_bold_t2s_wf
@@ -407,15 +407,18 @@ def init_bold_fit_wf(
         ])  # fmt:skip
     else:
         config.loggers.workflow.info('Found HMC boldref - skipping Stage 1')
-
-        validate_bold = pe.Node(ValidateImage(), name='validate_bold')
-        validate_bold.inputs.in_file = bold_file
-
         hmcref_buffer.inputs.boldref = precomputed['hmc_boldref']
 
+        validation_and_dummies_wf = init_validation_and_dummies_wf(bold_file=bold_file)
+
         workflow.connect([
-            (validate_bold, hmcref_buffer, [('out_file', 'bold_file')]),
-            (validate_bold, func_fit_reports_wf, [('out_report', 'inputnode.validation_report')]),
+            (validation_and_dummies_wf, hmcref_buffer, [
+                ('outputnode.bold_file', 'bold_file'),
+                ('outputnode.skip_vols', 'dummy_scans'),
+            ]),
+            (validation_and_dummies_wf, func_fit_reports_wf, [
+                ('outputnode.validation_report', 'inputnode.validation_report'),
+            ]),
             (hmcref_buffer, hmc_boldref_source_buffer, [('boldref', 'in_file')]),
         ])  # fmt:skip
 

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -591,6 +591,14 @@ def init_bold_fit_wf(
         config.loggers.workflow.info('Found coregistration reference - skipping Stage 3')
         regref_buffer.inputs.boldref = precomputed['coreg_boldref']
 
+        # TODO: Allow precomputed bold masks to be passed
+        # Also needs consideration for how it interacts above
+        skullstrip_precomp_ref_wf = init_skullstrip_bold_wf(name='skullstrip_precomp_ref_wf')
+        skullstrip_precomp_ref_wf.inputs.inputnode.in_file = precomputed['coreg_boldref']
+        workflow.connect([
+            (skullstrip_precomp_ref_wf, regref_buffer, [('outputnode.mask_file', 'boldmask')])
+        ])  # fmt:skip
+
     if not boldref2anat_xform:
         # calculate BOLD registration to T1w
         bold_reg_wf = init_bold_reg_wf(


### PR DESCRIPTION
This builds on #3427 to add a couple final things to the transform-only workflow:

```
fmriprep $BIDS $OUT participant --derivatives fmriprep=$MINIMAL
```

BOLD masks were not getting generated from the boldref and dummy scans were not being estimated.

This PR factors out the validation and dummy scan detection from `init_raw_boldref_wf` and uses the full workflow in fit mode and the subworkflow in transform mode.

Will rebase after #3427 is merged. Can compare now with: https://github.com/nipreps/fmriprep/compare/c28a6158e80bd054284533ff85f0ba5719606bb4...6c78e547d43ca4faa68ee72c21d872548daaf586

