### PR TITLE
fix(resampling): Use nearest mode for extrapolating data outside image boundaries

### DIFF
--- a/fmriprep/interfaces/resampling.py
+++ b/fmriprep/interfaces/resampling.py
@@ -54,8 +54,15 @@ class ResampleSeriesInputSpec(TraitedSpec):
     num_threads = traits.Int(1, usedefault=True, desc='Number of threads to use for resampling')
     output_data_type = traits.Str('float32', usedefault=True, desc='Data type of output image')
     order = traits.Int(3, usedefault=True, desc='Order of interpolation (0=nearest, 3=cubic)')
-    mode = traits.Str(
+    mode = traits.Enum(
+        'nearest',
         'constant',
+        'mirror',
+        'reflect',
+        'wrap',
+        'grid-constant',
+        'grid-mirror',
+        'grid-wrap',
         usedefault=True,
         desc='How data is extended beyond its boundaries. '
         'See scipy.ndimage.map_coordinates for more details.',


### PR DESCRIPTION
This PR addresses an interpolation effect when the brain signal goes right up to the edge of the image.

We have used the [scipy.ndimage.map_coordinates](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.map_coordinates.html) default interpolation mode of `"constant"`, which extends the input image with zeros when necessary to perform interpolation (within two voxels of the edge, for the cubic interpolation we do). This will frequently result in zeroed-out portions of edge voxels.

This generally works well when the image field of view is large enough to fully contain the brain, but can cause problems for limited field-of-view scans or images where the brain tissue can be found in the edge voxels.

By switching to `nearest`, the edge voxels are extended out. For images with plenty of space around the head, this should have very little impact. When brain tissue extends to the image boundary, this should avoid inducing a signal drop-off.

Closes #3452.