### PR TITLE
fix: Improve retrieval of precomputed pepolar fieldmaps

### DIFF
--- a/fmriprep/data/fmap_spec.json
+++ b/fmriprep/data/fmap_spec.json
@@ -21,7 +21,7 @@
       },
       "magnitude": {
         "datatype": "fmap",
-        "desc": "magnitude",
+        "desc": ["magnitude", "epi"],
         "suffix": "fieldmap",
         "extension": [
           ".nii.gz",


### PR DESCRIPTION
Discovered while testing precomputed derivatives in aslprep, which imports `fmriprep.utils.bids.collect_fieldmaps`. See https://github.com/PennLINC/aslprep/pull/518.

For PEPolar fieldmaps, the fieldmap reference is often `desc-epi_fieldmap.nii.gz`, as opposed to `desc-magnitude_fieldmap.nii.gz`. IMO, it would be good to change `desc-{epi,preproc}_fieldmap.nii.gz` to `desc-preproc_{magnitude,fieldmap}.nii.gz`, but this is what it is for now.