### PR TITLE
MNT: PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs", "nipreps-versions"]
+requires = ["hatchling>=1.27", "hatch-vcs", "nipreps-versions"]
 build-backend = "hatchling.build"
 
 [project]
@@ -11,13 +11,13 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Image Recognition",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-license = {file = "LICENSE"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "acres >= 0.2.0",


### PR DESCRIPTION
## Changes proposed in this pull request

Declare licenses using only these two fields, as per PEP 639:
* `license`: SPDX license expression consisting of one or more license identifiers
* `license-files`: list of license file glob patterns

Supported by hatchling ≥ 1.27.0:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

## Documentation that should be reviewed

N/A
