### PR TITLE
fix: Remove non-alphanumeric characters from fmapid in fmapreg transform

### DIFF
--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from collections import defaultdict
 from functools import cache
@@ -85,8 +86,8 @@ def collect_derivatives(
         #   whereas relevant src file will be "bold".
         query = {**entities, **q}
         if xfm == 'boldref2fmap' and fieldmap_id:
-            # fieldmaps have ids like auto_00000
-            query['to'] = fieldmap_id.replace('_', '')
+            # fieldmaps have non-alphanumeric characters removed from their IDs in filenames
+            query['to'] = re.sub(r'[^a-zA-Z0-9]', '', fieldmap_id)
         item = layout.get(return_type='filename', **query)
         if not item:
             continue

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -21,6 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 import os
+import re
 import typing as ty
 
 import bids
@@ -514,7 +515,7 @@ def init_bold_fit_wf(
                 bids_root=layout.root,
                 output_dir=config.execution.fmriprep_dir,
                 source='boldref',
-                dest=fieldmap_id.replace('_', ''),
+                dest=re.sub(r'[^a-zA-Z0-9]', '', fieldmap_id),
                 name='ds_fmapreg_wf',
             )
             ds_fmapreg_wf.inputs.inputnode.source_files = [bold_file]


### PR DESCRIPTION
Addresses the immediate symptoms in #3485. I can't promise that this will be the last such fix.

Associated changes for locating precomputed transforms are also made.

Closes #3485.