### PR TITLE
feat: Exclude non-steady-state volumes from confoundplot bounds, stats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "looseversion >= 1.3",
     "nibabel >= 4.0.1",
     "nipype >= 1.8.5",
-    "nireports @ git+https://github.com/nipreps/nireports.git@refs/pull/207/head",
+    "nireports @ git+https://github.com/nipreps/nireports.git@main",
     "nitime >= 0.9",
     "nitransforms >= 24.1.1",
     "niworkflows @ git+https://github.com/nipreps/niworkflows.git@master",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "looseversion >= 1.3",
     "nibabel >= 4.0.1",
     "nipype >= 1.8.5",
-    "nireports >= 24.1.0",
+    "nireports @ git+https://github.com/nipreps/nireports.git@refs/pull/206/head",
     "nitime >= 0.9",
     "nitransforms >= 24.1.1",
     "niworkflows @ git+https://github.com/nipreps/niworkflows.git@master",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "looseversion >= 1.3",
     "nibabel >= 4.0.1",
     "nipype >= 1.8.5",
-    "nireports @ git+https://github.com/nipreps/nireports.git@refs/pull/206/head",
+    "nireports @ git+https://github.com/nipreps/nireports.git@refs/pull/207/head",
     "nitime >= 0.9",
     "nitransforms >= 24.1.1",
     "niworkflows @ git+https://github.com/nipreps/niworkflows.git@master",


### PR DESCRIPTION
Includes nipreps/nireports#206.

Basically a smoke test to make sure that it works. ds005 and ds210 both have non-zero non-steady-state volumes.