### PR TITLE
FIX: Write out Freesurfer-derived outputs

### DIFF
--- a/.circleci/ds005_fasttrack_outputs.txt
+++ b/.circleci/ds005_fasttrack_outputs.txt
@@ -10,10 +10,14 @@ logs/CITATION.md
 logs/CITATION.tex
 sub-01
 sub-01/anat
+sub-01/anat/sub-01_desc-aparcaseg_dseg.nii.gz
+sub-01/anat/sub-01_desc-aseg_dseg.nii.gz
 sub-01/anat/sub-01_desc-ribbon_mask.json
 sub-01/anat/sub-01_desc-ribbon_mask.nii.gz
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-L_desc-preproc_sphere.surf.gii
 sub-01/anat/sub-01_hemi-L_desc-preproc_white.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
@@ -21,6 +25,8 @@ sub-01/anat/sub-01_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-preproc_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-preproc_white.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -10,6 +10,8 @@ logs/CITATION.md
 logs/CITATION.tex
 sub-01
 sub-01/anat
+sub-01/anat/sub-01_desc-aparcaseg_dseg.nii.gz
+sub-01/anat/sub-01_desc-aseg_dseg.nii.gz
 sub-01/anat/sub-01_desc-brain_mask.json
 sub-01/anat/sub-01_desc-brain_mask.nii.gz
 sub-01/anat/sub-01_desc-preproc_T1w.json
@@ -23,6 +25,8 @@ sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 sub-01/anat/sub-01_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-L_pial.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
@@ -34,6 +38,8 @@ sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 sub-01/anat/sub-01_hemi-L_white.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-R_pial.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -23,10 +23,10 @@ sub-01/anat/sub-01_from-fsnative_to-T1w_mode-image_xfm.txt
 sub-01/anat/sub-01_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5
 sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 sub-01/anat/sub-01_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5
+sub-01/anat/sub-01_hemi-L_curv.shape.gii
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
-sub-01/anat/sub-01_hemi-L_desc-preproc_curv.shape.gii
-sub-01/anat/sub-01_hemi-L_desc-preproc_inflated.surf.gii
+sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-L_pial.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
@@ -36,10 +36,10 @@ sub-01/anat/sub-01_hemi-L_sphere.surf.gii
 sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 sub-01/anat/sub-01_hemi-L_white.surf.gii
+sub-01/anat/sub-01_hemi-R_curv.shape.gii
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
-sub-01/anat/sub-01_hemi-R_desc-preproc_curv.shape.gii
-sub-01/anat/sub-01_hemi-R_desc-preproc_inflated.surf.gii
+sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-R_pial.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii

--- a/.circleci/ds005_partial_fasttrack_outputs.txt
+++ b/.circleci/ds005_partial_fasttrack_outputs.txt
@@ -10,10 +10,14 @@ logs/CITATION.md
 logs/CITATION.tex
 sub-01
 sub-01/anat
+sub-01/anat/sub-01_desc-aparcaseg_dseg.nii.gz
+sub-01/anat/sub-01_desc-aseg_dseg.nii.gz
 sub-01/anat/sub-01_desc-ribbon_mask.json
 sub-01/anat/sub-01_desc-ribbon_mask.nii.gz
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-L_desc-preproc_sphere.surf.gii
 sub-01/anat/sub-01_hemi-L_desc-preproc_white.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsLR_den-32k_desc-preproc_midthickness.surf.gii
@@ -24,6 +28,8 @@ sub-01/anat/sub-01_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-preproc_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-preproc_white.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_den-32k_desc-preproc_midthickness.surf.gii

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -25,10 +25,10 @@ sub-01/anat/sub-01_from-MNI152NLin6Asym_to-T1w_mode-image_xfm.h5
 sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 sub-01/anat/sub-01_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5
 sub-01/anat/sub-01_from-T1w_to-MNI152NLin6Asym_mode-image_xfm.h5
+sub-01/anat/sub-01_hemi-L_curv.shape.gii
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
-sub-01/anat/sub-01_hemi-L_desc-preproc_curv.shape.gii
-sub-01/anat/sub-01_hemi-L_desc-preproc_inflated.surf.gii
+sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-L_pial.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsLR_den-32k_midthickness.surf.gii
@@ -41,10 +41,10 @@ sub-01/anat/sub-01_hemi-L_sphere.surf.gii
 sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 sub-01/anat/sub-01_hemi-L_white.surf.gii
+sub-01/anat/sub-01_hemi-R_curv.shape.gii
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
-sub-01/anat/sub-01_hemi-R_desc-preproc_curv.shape.gii
-sub-01/anat/sub-01_hemi-R_desc-preproc_inflated.surf.gii
+sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-R_pial.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_den-32k_midthickness.surf.gii

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -10,6 +10,8 @@ logs/CITATION.md
 logs/CITATION.tex
 sub-01
 sub-01/anat
+sub-01/anat/sub-01_desc-aparcaseg_dseg.nii.gz
+sub-01/anat/sub-01_desc-aseg_dseg.nii.gz
 sub-01/anat/sub-01_desc-brain_mask.json
 sub-01/anat/sub-01_desc-brain_mask.nii.gz
 sub-01/anat/sub-01_desc-preproc_T1w.json
@@ -25,6 +27,8 @@ sub-01/anat/sub-01_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5
 sub-01/anat/sub-01_from-T1w_to-MNI152NLin6Asym_mode-image_xfm.h5
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
 sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-L_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-L_pial.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsLR_den-32k_midthickness.surf.gii
@@ -37,8 +41,10 @@ sub-01/anat/sub-01_hemi-L_sphere.surf.gii
 sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 sub-01/anat/sub-01_hemi-L_white.surf.gii
-sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
-sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-R_desc-cortex_mask.json
+sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_curv.shape.gii
+sub-01/anat/sub-01_hemi-R_desc-preproc_inflated.surf.gii
 sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 sub-01/anat/sub-01_hemi-R_pial.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_den-32k_midthickness.surf.gii

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -421,17 +421,10 @@ It is released under the [CC0]\
             ])  # fmt:skip
 
         if freesurfer:
-            from smriprep.workflows.outputs import (
-                init_ds_fs_segs_wf,
-                init_ds_surface_metrics_wf,
-                init_ds_surfaces_wf,
-            )
+            from smriprep.workflows.outputs import init_ds_fs_segs_wf, init_ds_surface_metrics_wf
             from smriprep.workflows.surfaces import init_surface_derivatives_wf
 
-            ds_fs_segs_wf = init_ds_fs_segs_wf(
-                bids_root=bids_root,
-                output_dir=fmriprep_dir,
-            )
+            ds_fs_segs_wf = init_ds_fs_segs_wf(bids_root=bids_root, output_dir=fmriprep_dir)
             surface_derivatives_wf = init_surface_derivatives_wf()
             ds_surfaces_wf = init_ds_surfaces_wf(output_dir=fmriprep_dir, surfaces=['inflated'])
             ds_curv_wf = init_ds_surface_metrics_wf(

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -214,6 +214,7 @@ It is released under the [CC0]\
     if 't2w' in config.workflow.ignore:
         subject_data['t2w'] = []
 
+    freesurfer = config.workflow.run_reconall
     anat_only = config.workflow.anat_only
     # Make sure we always go through these two checks
     if not anat_only and not subject_data['bold']:
@@ -319,7 +320,7 @@ It is released under the [CC0]\
     anat_fit_wf = init_anat_fit_wf(
         bids_root=bids_root,
         output_dir=fmriprep_dir,
-        freesurfer=config.workflow.run_reconall,
+        freesurfer=freesurfer,
         hires=config.workflow.hires,
         fs_no_resume=config.workflow.fs_no_resume,
         longitudinal=config.workflow.longitudinal,
@@ -416,6 +417,53 @@ It is released under the [CC0]\
                 (anat_fit_wf, select_MNI2009c_xfm, [
                     ('outputnode.std2anat_xfm', 'std2anat_xfm'),
                     ('outputnode.template', 'keys'),
+                ]),
+            ])  # fmt:skip
+
+        if freesurfer:
+            from smriprep.workflows.outputs import (
+                init_ds_fs_segs_wf,
+                init_ds_surface_metrics_wf,
+                init_ds_surfaces_wf,
+            )
+            from smriprep.workflows.surfaces import init_surface_derivatives_wf
+
+            ds_fs_segs_wf = init_ds_fs_segs_wf(
+                bids_root=bids_root,
+                output_dir=fmriprep_dir,
+            )
+            surface_derivatives_wf = init_surface_derivatives_wf()
+            ds_surfaces_wf = init_ds_surfaces_wf(output_dir=fmriprep_dir, surfaces=['inflated'])
+            ds_curv_wf = init_ds_surface_metrics_wf(
+                bids_root=bids_root,
+                output_dir=fmriprep_dir,
+                metrics=['curv'],
+                name='ds_curv_wf',
+            )
+
+            workflow.connect([
+                (anat_fit_wf, surface_derivatives_wf, [
+                    ('outputnode.t1w_preproc', 'inputnode.reference'),
+                    ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
+                    ('outputnode.subject_id', 'inputnode.subject_id'),
+                    ('outputnode.fsnative2t1w_xfm', 'inputnode.fsnative2anat_xfm'),
+                ]),
+                (anat_fit_wf, ds_surfaces_wf, [
+                    ('outputnode.t1w_valid_list', 'inputnode.source_files'),
+                ]),
+                (surface_derivatives_wf, ds_surfaces_wf, [
+                    ('outputnode.inflated', 'inputnode.inflated'),
+                ]),
+                (anat_fit_wf, ds_curv_wf, [
+                    ('outputnode.t1w_valid_list', 'inputnode.source_files'),
+                ]),
+                (surface_derivatives_wf, ds_curv_wf, [('outputnode.curv', 'inputnode.curv')]),
+                (anat_fit_wf, ds_fs_segs_wf, [
+                    ('outputnode.t1w_valid_list', 'inputnode.source_files'),
+                ]),
+                (surface_derivatives_wf, ds_fs_segs_wf, [
+                    ('outputnode.out_aseg', 'inputnode.anat_fs_aseg'),
+                    ('outputnode.out_aparc', 'inputnode.anat_fs_aparc'),
                 ]),
             ])  # fmt:skip
 


### PR DESCRIPTION
Closes #3511. I don't think I accounted for the versions of aseg and aparcaseg that get written out to the func directory, and I haven't thought about precomputed derivatives at all.

## Changes proposed in this pull request

- Add Freesurfer-related section from sMRIPrep's `init_anat_preproc_wf` to `init_single_subject_wf`