### PR TITLE
ENH: Write out goodvoxels mask

### DIFF
--- a/.circleci/ds005_partial_fasttrack_outputs.txt
+++ b/.circleci/ds005_partial_fasttrack_outputs.txt
@@ -106,6 +106,7 @@ sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-brain_mask.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-brain_mask.nii.gz
+sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-goodvoxels_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.nii.gz
 sub-01.html

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -128,6 +128,7 @@ sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-brain_mask.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-brain_mask.nii.gz
+sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-goodvoxels_mask.nii.gz
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.json
 sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.nii.gz
 sub-01.html

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -572,6 +572,24 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 (bold_anat_wf, goodvoxels_bold_mask_wf, [
                     ('outputnode.bold_file', 'inputnode.bold_file'),
                 ]),
+            ])  # fmt:skip
+
+            ds_goodvoxels_mask = pe.Node(
+                DerivativesDataSink(
+                    base_directory=fmriprep_dir,
+                    dismiss_entities=dismiss_echo(),
+                    space='T1w',
+                    desc='goodvoxels',
+                    suffix='mask',
+                ),
+                name='ds_goodvoxels_mask',
+                run_without_submitting=True,
+            )
+            ds_goodvoxels_mask.inputs.source_file = bold_file
+            workflow.connect([
+                (goodvoxels_bold_mask_wf, ds_goodvoxels_mask, [
+                    ('outputnode.goodvoxels_mask', 'in_file'),
+                ]),
                 (goodvoxels_bold_mask_wf, bold_fsLR_resampling_wf, [
                     ('outputnode.goodvoxels_mask', 'inputnode.volume_roi'),
                 ]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -578,6 +578,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 DerivativesDataSink(
                     base_directory=fmriprep_dir,
                     dismiss_entities=dismiss_echo(),
+                    compress=True,
                     space='T1w',
                     desc='goodvoxels',
                     suffix='mask',


### PR DESCRIPTION
Closes #3510. I'm happy to move the DerivativesDataSink into `init_goodvoxels_bold_mask_wf` if the current approach clutters up the workflow too much.

## Changes proposed in this pull request

- Add a DerivativesDataSink to `init_bold_wf` to write out the goodvoxels mask.
- Update the expected outputs for relevant tests.