### PR TITLE
STY: Make use of f-strings extensive

### DIFF
--- a/.maint/paper_author_list.py
+++ b/.maint/paper_author_list.py
@@ -46,26 +46,15 @@ if __name__ == '__main__':
     ]
 
     print(
-        'Some people made commits, but are missing in .maint/ files: {}.'.format(
-            ', '.join(unmatched)
-        ),
+        f'Some people made commits, but are missing in .maint/ files: {", ".join(unmatched)}.',
         file=sys.stderr,
     )
 
     print(f'Authors ({len(author_matches)}):')
-    print(
-        '{}.'.format(
-            '; '.join(
-                [
-                    rf'{i["name"]} \ :sup:`{idx}`\ '
-                    for i, idx in zip(author_matches, aff_indexes, strict=False)
-                ]
-            )
-        )
+    authors = '; '.join(
+        f'{i["name"]} \\ :sup:`{idx}`\\ ' for i, idx in zip(hits, aff_indexes, strict=False)
     )
+    print(f'{authors}.')
 
-    print(
-        '\n\nAffiliations:\n{}'.format(
-            '\n'.join([f'{i + 1: >2}. {a}' for i, a in enumerate(affiliations)])
-        )
-    )
+    lines = '\n'.join(f'{i + 1: >2}. {a}' for i, a in enumerate(affiliations))
+    print(f'\n\nAffiliations:\n{lines}')

--- a/.maint/update_authors.py
+++ b/.maint/update_authors.py
@@ -119,12 +119,11 @@ def get_git_lines(fname='line-contributors.txt'):
 
     if not lines:
         raise RuntimeError(
-            """\
-Could not find line-contributors from git repository.{}""".format(
-                """ \
-git-line-summary not found, please install git-extras. """
+            f"""\
+Could not find line-contributors from git repository.{
+                ' git-line-summary not found, please install git-extras.'
                 * (git_line_summary_path is None)
-            )
+            }"""
         )
     return [' '.join(line.strip().split()[1:-1]) for line in lines if '%' in line]
 
@@ -273,22 +272,11 @@ def publication(
         )
 
     print(f'Authors ({len(hits)}):')
-    print(
-        '{}.'.format(
-            '; '.join(
-                [
-                    rf'{i["name"]} \ :sup:`{idx}`\ '
-                    for i, idx in zip(hits, aff_indexes, strict=False)
-                ]
-            )
-        )
-    )
+    authors = f'{"; ".join(rf"{i['name']} \ :sup:`{idx}`\ " for i, idx in zip(hits, aff_indexes, strict=False))}.'
+    print(f'{authors}.')
 
-    print(
-        '\n\nAffiliations:\n{}'.format(
-            '\n'.join([f'{i + 1: >2}. {a}' for i, a in enumerate(affiliations)])
-        )
-    )
+    lines = '\n'.join(f'{i + 1: >2}. {a}' for i, a in enumerate(affiliations))
+    print(f'\n\nAffiliations:\n{lines}')
 
 
 if __name__ == '__main__':

--- a/.maint/update_zenodo.py
+++ b/.maint/update_zenodo.py
@@ -87,12 +87,10 @@ def get_git_lines(fname='line-contributors.txt'):
 
     if not lines:
         raise RuntimeError(
-            """\
-Could not find line-contributors from git repository.{}""".format(
-                """ \
-git-(line-)summary not found, please install git-extras. """
-                * (cmd[0] is None)
-            )
+            f"""\
+Could not find line-contributors from git repository.{
+                ' git(-line-)summary not found, please install git-extras.' * (cmd[0] is None)
+            }"""
         )
     return [' '.join(line.strip().split()[1:-1]) for line in lines if '%' in line]
 
@@ -121,7 +119,7 @@ def loads_contributors(s):
     return [
         {
             'affiliation': contributor['Affiliation'],
-            'name': '{}, {}'.format(contributor['Lastname'], contributor['Name']),
+            'name': f'{contributor["Lastname"]}, {contributor["Name"]}',
             'orcid': contributor['ORCID'],
         }
         for contributor in loads_table_from_markdown(s)
@@ -151,12 +149,12 @@ if __name__ == '__main__':
     zenodo['creators'] = zen_creators
     zenodo['contributors'] = zen_contributors
 
-    print(
-        'Some people made commits, but are missing in .maint/ files: {}.'.format(
-            ', '.join(set(miss_creators).intersection(miss_contributors))
-        ),
-        file=sys.stderr,
-    )
+    missing = {*miss_creators} & {*miss_contributors}
+    if missing:
+        print(
+            f'Some people made commits, but are missing in .maint/ files: {", ".join(sorted(missing))}.',
+            file=sys.stderr,
+        )
 
     # Remove position
     for creator in zenodo['creators']:

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -243,9 +243,8 @@ def _build_parser(**kwargs):
         metavar='FILE',
         help='A JSON file describing custom BIDS input filters using PyBIDS. '
         'For further details, please check out '
-        'https://fmriprep.readthedocs.io/en/%s/faq.html#'
-        'how-do-I-select-only-certain-files-to-be-input-to-fMRIPrep'
-        % (currentv.base_version if is_release else 'latest'),
+        f'https://fmriprep.readthedocs.io/en/{currentv.base_version if is_release else "latest"}/faq.html#'
+        'how-do-I-select-only-certain-files-to-be-input-to-fMRIPrep',
     )
     g_bids.add_argument(
         '-d',
@@ -369,7 +368,7 @@ def _build_parser(**kwargs):
         '--output-spaces',
         nargs='*',
         action=OutputReferencesAction,
-        help="""\
+        help=f"""\
 Standard and non-standard spaces to resample anatomical and functional images to. \
 Standard spaces may be specified by the form \
 ``<SPACE>[:cohort-<label>][:res-<resolution>][...]``, where ``<SPACE>`` is \
@@ -379,8 +378,7 @@ Non-standard spaces imply specific orientations and sampling grids. \
 Important to note, the ``res-*`` modifier does not define the resolution used for \
 the spatial normalization. To generate no BOLD outputs, use this option without specifying \
 any spatial references. For further details, please check out \
-https://fmriprep.readthedocs.io/en/%s/spaces.html"""
-        % (currentv.base_version if is_release else 'latest'),
+https://fmriprep.readthedocs.io/en/{currentv.base_version if is_release else 'latest'}/spaces.html""",
     )
     g_conf.add_argument(
         '--longitudinal',
@@ -893,11 +891,10 @@ applied."""
 
     # Ensure input and output folders are not the same
     if output_dir == bids_dir:
+        ver = version.split('+')[0]
         parser.error(
             'The selected output folder is the same as the input BIDS folder. '
-            'Please modify the output path (suggestion: {}).'.format(
-                bids_dir / 'derivatives' / f'fmriprep-{version.split("+")[0]}'
-            )
+            f'Please modify the output path (suggestion: {bids_dir / "derivatives" / f"fmriprep-{ver}"}).'
         )
 
     if bids_dir in work_dir.parents:
@@ -936,9 +933,7 @@ applied."""
     missing_subjects = participant_label - set(all_subjects)
     if missing_subjects:
         parser.error(
-            'One or more participant labels were not found in the BIDS directory: {}.'.format(
-                ', '.join(missing_subjects)
-            )
+            f'One or more participant labels were not found in the BIDS directory: {", ".join(missing_subjects)}.'
         )
 
     config.execution.participant_label = sorted(participant_label)

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -154,7 +154,7 @@ def main():
 
             if sentry_sdk is not None and 'Workflow did not execute cleanly' not in str(e):
                 sentry_sdk.capture_exception(e)
-        config.loggers.workflow.critical('fMRIPrep failed: %s', e)
+        config.loggers.workflow.critical(f'fMRIPrep failed: {e}')
         raise
     else:
         config.loggers.workflow.log(25, 'fMRIPrep finished successfully!')

--- a/fmriprep/cli/workflow.py
+++ b/fmriprep/cli/workflow.py
@@ -84,7 +84,7 @@ def build_workflow(config_file, retval):
 
     # Called with reports only
     if config.execution.reports_only:
-        build_log.log(25, 'Running --reports-only on participants %s', ', '.join(subject_list))
+        build_log.log(25, f'Running --reports-only on participants {", ".join(subject_list)}')
         session_list = (
             config.execution.bids_filters.get('bold', {}).get('session')
             if config.execution.bids_filters
@@ -99,8 +99,7 @@ def build_workflow(config_file, retval):
         )
         if failed_reports:
             config.loggers.cli.error(
-                'Report generation was not successful for the following participants : %s.',
-                ', '.join(failed_reports),
+                f'Report generation was not successful for the following participants : {", ".join(failed_reports)}.'
             )
 
         retval['return_code'] = len(failed_reports)
@@ -150,17 +149,14 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     # Check workflow for missing commands
     missing = check_deps(retval['workflow'])
     if missing:
-        build_log.critical(
-            'Cannot run fMRIPrep. Missing dependencies:%s',
-            '\n\t* '.join([''] + [f'{cmd} (Interface: {iface})' for iface, cmd in missing]),
-        )
+        deps_list = '\n'.join([f'\t* {cmd} (Interface: {iface})' for iface, cmd in missing])
+        build_log.critical(f'Cannot run fMRIPrep. Missing dependencies:\n{deps_list}')
         retval['return_code'] = 127  # 127 == command not found.
         return retval
 
     config.to_filename(config_file)
     build_log.info(
-        'fMRIPrep workflow graph with %d nodes built successfully.',
-        len(retval['workflow']._get_all_nodes()),
+        f'fMRIPrep workflow graph with {len(retval["workflow"]._get_all_nodes())} nodes built successfully.'
     )
     retval['return_code'] = 0
     return retval
@@ -215,7 +211,7 @@ def build_boilerplate(config_file, workflow):
         try:
             check_call(cmd, timeout=10)
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
-            config.loggers.cli.warning('Could not generate CITATION.html file:\n%s', ' '.join(cmd))
+            config.loggers.cli.warning(f'Could not generate CITATION.html file:\n{" ".join(cmd)}')
 
         # Generate LaTex file resolving citations
         cmd = [
@@ -232,4 +228,4 @@ def build_boilerplate(config_file, workflow):
         try:
             check_call(cmd, timeout=10)
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
-            config.loggers.cli.warning('Could not generate CITATION.tex file:\n%s', ' '.join(cmd))
+            config.loggers.cli.warning(f'Could not generate CITATION.tex file:\n{" ".join(cmd)}')

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -198,7 +198,7 @@ try:
             if _proc_oc_kbytes.exists():
                 _oc_limit = _proc_oc_kbytes.read_text().strip()
             if _oc_limit in ('0', 'n/a') and Path('/proc/sys/vm/overcommit_ratio').exists():
-                _oc_limit = '{}%'.format(Path('/proc/sys/vm/overcommit_ratio').read_text().strip())
+                _oc_limit = f'{Path("/proc/sys/vm/overcommit_ratio").read_text().strip()}%'
 except Exception:  # noqa: S110, BLE001
     pass
 

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -264,14 +264,20 @@ class FunctionalSummary(SummaryInterface):
         dummy_scan_tmp = '{n_dum}'
         if self.inputs.dummy_scans == self.inputs.algo_dummy_scans:
             dummy_scan_msg = ' '.join(
-                [dummy_scan_tmp, '(Confirmed: {n_alg} automatically detected)']
-            ).format(n_dum=self.inputs.dummy_scans, n_alg=self.inputs.algo_dummy_scans)
+                [
+                    dummy_scan_tmp,
+                    f'(Confirmed: {self.inputs.algo_dummy_scans} automatically detected)',
+                ]
+            ).format(n_dum=self.inputs.dummy_scans)
         # the number of dummy scans was specified by the user and
         # it is not equal to the number detected by the algorithm
         elif self.inputs.dummy_scans is not None:
             dummy_scan_msg = ' '.join(
-                [dummy_scan_tmp, '(Warning: {n_alg} automatically detected)']
-            ).format(n_dum=self.inputs.dummy_scans, n_alg=self.inputs.algo_dummy_scans)
+                [
+                    dummy_scan_tmp,
+                    f'(Warning: {self.inputs.algo_dummy_scans} automatically detected)',
+                ]
+            ).format(n_dum=self.inputs.dummy_scans)
         # the number of dummy scans was not specified by the user
         else:
             dummy_scan_msg = dummy_scan_tmp.format(n_dum=self.inputs.algo_dummy_scans)

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -267,14 +267,9 @@ class FunctionalSummary(SummaryInterface):
         # it is not equal to the number detected by the algorithm
         elif self.inputs.dummy_scans is not None:
             dummy_scan_msg = f'{self.inputs.dummy_scans} (Warning: {self.inputs.algo_dummy_scans} automatically detected)'
-                [
-                    dummy_scan_tmp,
-                    f'(Warning: {self.inputs.algo_dummy_scans} automatically detected)',
-                ]
-            ).format(n_dum=self.inputs.dummy_scans)
         # the number of dummy scans was not specified by the user
         else:
-            dummy_scan_msg = dummy_scan_tmp.format(n_dum=self.inputs.algo_dummy_scans)
+            dummy_scan_msg = f'{self.inputs.algo_dummy_scans}'
 
         multiecho = 'Single-echo EPI sequence.'
         n_echos = len(self.inputs.echo_idx)

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -261,9 +261,8 @@ class FunctionalSummary(SummaryInterface):
 
         pedir = get_world_pedir(self.inputs.orientation, self.inputs.pe_direction)
 
-        dummy_scan_tmp = '{n_dum}'
         if self.inputs.dummy_scans == self.inputs.algo_dummy_scans:
-            dummy_scan_msg = ' '.join(
+            dummy_scan_msg = f'{self.inputs.dummy_scans} (Confirmed: {self.inputs.algo_dummy_scans} automatically detected)'
                 [
                     dummy_scan_tmp,
                     f'(Confirmed: {self.inputs.algo_dummy_scans} automatically detected)',

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -263,15 +263,10 @@ class FunctionalSummary(SummaryInterface):
 
         if self.inputs.dummy_scans == self.inputs.algo_dummy_scans:
             dummy_scan_msg = f'{self.inputs.dummy_scans} (Confirmed: {self.inputs.algo_dummy_scans} automatically detected)'
-                [
-                    dummy_scan_tmp,
-                    f'(Confirmed: {self.inputs.algo_dummy_scans} automatically detected)',
-                ]
-            ).format(n_dum=self.inputs.dummy_scans)
         # the number of dummy scans was specified by the user and
         # it is not equal to the number detected by the algorithm
         elif self.inputs.dummy_scans is not None:
-            dummy_scan_msg = ' '.join(
+            dummy_scan_msg = f'{self.inputs.dummy_scans} (Warning: {self.inputs.algo_dummy_scans} automatically detected)'
                 [
                     dummy_scan_tmp,
                     f'(Warning: {self.inputs.algo_dummy_scans} automatically detected)',

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -274,7 +274,7 @@ def validate_input_dir(exec_env, bids_dir, participant_label, need_T1w=True):
                     'all paths are mapped properly (see https://www.sylabs.io/'
                     'guides/3.0/user-guide/bind_paths_and_mounts.html)'
                 )
-            raise RuntimeError(error_msg % ','.join(bad_labels))
+            raise RuntimeError(error_msg.format(','.join(bad_labels)))
 
         ignored_subs = all_subs.difference(selected_subs)
         if ignored_subs:

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -274,7 +274,7 @@ def validate_input_dir(exec_env, bids_dir, participant_label, need_T1w=True):
                     'all paths are mapped properly (see https://www.sylabs.io/'
                     'guides/3.0/user-guide/bind_paths_and_mounts.html)'
                 )
-            raise RuntimeError(error_msg.format(','.join(bad_labels)))
+            raise RuntimeError(error_msg % ','.join(bad_labels))
 
         ignored_subs = all_subs.difference(selected_subs)
         if ignored_subs:

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -85,7 +85,7 @@ def init_fmriprep_wf():
                 spaces=config.workflow.spaces.get_fs_spaces(),
                 minimum_fs_version='7.0.0',
             ),
-            name='fsdir_run_{}'.format(config.execution.run_uuid.replace('-', '_')),
+            name=f'fsdir_run_{config.execution.run_uuid.replace("-", "_")}',
             run_without_submitting=True,
         )
         if config.execution.fs_subjects_dir is not None:
@@ -340,7 +340,7 @@ It is released under the [CC0]\
     # allow to run with anat-fast-track on fMRI-only dataset
     if 't1w_preproc' in anatomical_cache and not subject_data['t1w']:
         config.loggers.workflow.debug(
-            'No T1w image found; using precomputed T1w image: %s', anatomical_cache['t1w_preproc']
+            f'No T1w image found; using precomputed T1w image: {anatomical_cache["t1w_preproc"]}',
         )
         workflow.connect([
             (bidssrc, bids_info, [(('bold', fix_multi_T1w_source_name), 'in_file')]),
@@ -588,7 +588,7 @@ It is released under the [CC0]\
                 entities={'subject': subject_id},
             )
             config.loggers.workflow.debug(
-                'Detected precomputed fieldmaps in %s for fieldmap IDs: %s', deriv_dir, list(fmaps)
+                f'Detected precomputed fieldmaps in {deriv_dir} for fieldmap IDs: {list(fmaps)}',
             )
             fmap_cache.update(fmaps)
 
@@ -627,9 +627,9 @@ It is released under the [CC0]\
             fieldmaps = [fmap['fieldmap'] for fmap in pared_cache.values()]
             refs = [fmap['magnitude'] for fmap in pared_cache.values()]
             coeffs = [fmap['coeffs'] for fmap in pared_cache.values()]
-            config.loggers.workflow.debug('Reusing fieldmaps: %s', fieldmaps)
-            config.loggers.workflow.debug('Reusing references: %s', refs)
-            config.loggers.workflow.debug('Reusing coefficients: %s', coeffs)
+            config.loggers.workflow.debug(f'Reusing fieldmaps: {fieldmaps}')
+            config.loggers.workflow.debug(f'Reusing references: {refs}')
+            config.loggers.workflow.debug(f'Reusing coefficients: {coeffs}')
 
             fmap_buffers['fmap'].inputs.in1 = fieldmaps
             fmap_buffers['fmap_ref'].inputs.in1 = refs

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -184,13 +184,8 @@ def init_bold_wf(
         return
 
     config.loggers.workflow.debug(
-        'Creating bold processing workflow for <%s> (%.2f GB / %d TRs). '
-        'Memory resampled/largemem=%.2f/%.2f GB.',
-        bold_file,
-        mem_gb['filesize'],
-        nvols,
-        mem_gb['resampled'],
-        mem_gb['largemem'],
+        f'Creating bold processing workflow for <{bold_file}> ({mem_gb["filesize"]:.2f} GB / {nvols} TRs). '
+        f'Memory resampled/largemem={mem_gb["resampled"]:.2f}/{mem_gb["largemem"]:.2f} GB.'
     )
 
     workflow = Workflow(name=_get_wf_name(bold_file, 'bold'))

--- a/fmriprep/workflows/bold/fit.py
+++ b/fmriprep/workflows/bold/fit.py
@@ -221,9 +221,7 @@ def init_bold_fit_wf(
         sbref_msg = f'Single-band reference file(s) found for {basename} and ignored.'
         sbref_files = []
     elif sbref_files:
-        sbref_msg = 'Using single-band reference file(s) {}.'.format(
-            ','.join([os.path.basename(sbf) for sbf in sbref_files])
-        )
+        sbref_msg = f'Using single-band reference file(s) {",".join([os.path.basename(sbf) for sbf in sbref_files])}.'
     config.loggers.workflow.info(sbref_msg)
 
     # Get metadata from BOLD file(s)
@@ -306,16 +304,16 @@ def init_bold_fit_wf(
 
     if hmc_boldref:
         hmcref_buffer.inputs.boldref = hmc_boldref
-        config.loggers.workflow.debug('Reusing motion correction reference: %s', hmc_boldref)
+        config.loggers.workflow.debug(f'Reusing motion correction reference: {hmc_boldref}')
     if hmc_xforms:
         hmc_buffer.inputs.hmc_xforms = hmc_xforms
-        config.loggers.workflow.debug('Reusing motion correction transforms: %s', hmc_xforms)
+        config.loggers.workflow.debug(f'Reusing motion correction transforms: {hmc_xforms}')
     if boldref2fmap_xform:
         fmapreg_buffer.inputs.boldref2fmap_xfm = boldref2fmap_xform
-        config.loggers.workflow.debug('Reusing BOLD-to-fieldmap transform: %s', boldref2fmap_xform)
+        config.loggers.workflow.debug(f'Reusing BOLD-to-fieldmap transform: {boldref2fmap_xform}')
     if coreg_boldref:
         regref_buffer.inputs.boldref = coreg_boldref
-        config.loggers.workflow.debug('Reusing coregistration reference: %s', coreg_boldref)
+        config.loggers.workflow.debug(f'Reusing coregistration reference: {coreg_boldref}')
     fmapref_buffer.inputs.sbref_files = sbref_files
 
     summary = pe.Node(

--- a/fmriprep/workflows/bold/hmc.py
+++ b/fmriprep/workflows/bold/hmc.py
@@ -77,12 +77,12 @@ def init_bold_hmc_wf(mem_gb: float, omp_nthreads: int, name: str = 'bold_hmc_wf'
     from niworkflows.interfaces.itk import MCFLIRT2ITK
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """\
+    workflow.__desc__ = f"""\
 Head-motion parameters with respect to the BOLD reference
 (transformation matrices, and six corresponding rotation and translation
 parameters) are estimated before any spatiotemporal filtering using
-`mcflirt` [FSL {fsl_ver}, @mcflirt].
-""".format(fsl_ver=fsl.Info().version() or '<ver>')
+`mcflirt` [FSL {fsl.Info().version() or '<ver>'}, @mcflirt].
+"""
 
     inputnode = pe.Node(
         niu.IdentityInterface(fields=['bold_file', 'raw_ref_image']), name='inputnode'

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -283,18 +283,15 @@ def init_bbreg_wf(
     from fmriprep.interfaces.patches import FreeSurferSource, MRICoreg
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """\
+    dof_text = {6: 'six', 9: 'nine', 12: 'twelve'}[bold2anat_dof]
+    reason_text = (
+        '' if bold2anat_dof == 6 else ' to account for distortions remaining in the BOLD reference'
+    )
+    workflow.__desc__ = f"""\
 The BOLD reference was then co-registered to the T1w reference using
 `bbregister` (FreeSurfer) which implements boundary-based registration [@bbr].
-Co-registration was configured with {dof} degrees of freedom{reason}.
-""".format(
-        dof={6: 'six', 9: 'nine', 12: 'twelve'}[bold2anat_dof],
-        reason=(
-            ''
-            if bold2anat_dof == 6
-            else 'to account for distortions remaining in the BOLD reference'
-        ),
-    )
+Co-registration was configured with {dof_text} degrees of freedom{reason_text}.
+"""
 
     use_t2w = bold2anat_init == 't2w'
     if use_t2w:
@@ -550,20 +547,17 @@ def init_fsl_bbr_wf(
     from niworkflows.utils.images import dseg_label as _dseg_label
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """\
+    fsl_ver = fsl.FLIRT().version or '<ver>'
+    dof_text = {6: 'six', 9: 'nine', 12: 'twelve'}[bold2anat_dof]
+    reason_text = (
+        '' if bold2anat_dof == 6 else ' to account for distortions remaining in the BOLD reference'
+    )
+    workflow.__desc__ = f"""\
 The BOLD reference was then co-registered to the T1w reference using
 `mri_coreg` (FreeSurfer) followed by `flirt` [FSL {fsl_ver}, @flirt]
 with the boundary-based registration [@bbr] cost-function.
-Co-registration was configured with {dof} degrees of freedom{reason}.
-""".format(
-        fsl_ver=fsl.FLIRT().version or '<ver>',
-        dof={6: 'six', 9: 'nine', 12: 'twelve'}[bold2anat_dof],
-        reason=(
-            ''
-            if bold2anat_dof == 6
-            else 'to account for distortions remaining in the BOLD reference'
-        ),
-    )
+Co-registration was configured with {dof_text} degrees of freedom{reason_text}.
+"""
 
     inputnode = pe.Node(
         niu.IdentityInterface(

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -122,11 +122,11 @@ def init_bold_surf_wf(
     timing_parameters = prepare_timing_parameters(metadata)
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """\
+    workflow.__desc__ = f"""\
 The BOLD time-series were resampled onto the following surfaces
 (FreeSurfer reconstruction nomenclature):
-{out_spaces}.
-""".format(out_spaces=', '.join([f'*{s}*' for s in surface_spaces]))
+{', '.join([f'*{s}*' for s in surface_spaces])}.
+"""
 
     inputnode = pe.Node(
         niu.IdentityInterface(


### PR DESCRIPTION
## Changes proposed in this pull request

Make use of f-strings extensive: prefer using f-strings for string interpolation and formatting instead of the modulo operator and the `str.format()` method.

f-strings have become the preferred method for Python string formatting since their introduction in Python 3.6:
https://peps.python.org/pep-0498/

The code becomes more concise and readable.

N/A.
