### PR TITLE
fix: Default to grid-constant interpolation mode

### DIFF
--- a/fmriprep/interfaces/resampling.py
+++ b/fmriprep/interfaces/resampling.py
@@ -54,12 +54,12 @@ class ResampleSeriesInputSpec(TraitedSpec):
     output_data_type = traits.Str('float32', usedefault=True, desc='Data type of output image')
     order = traits.Int(3, usedefault=True, desc='Order of interpolation (0=nearest, 3=cubic)')
     mode = traits.Enum(
+        'grid-constant',
         'nearest',
         'constant',
         'mirror',
         'reflect',
         'wrap',
-        'grid-constant',
         'grid-mirror',
         'grid-wrap',
         usedefault=True,


### PR DESCRIPTION
This is a potential fix to #3475 and #3508. To test:

```
git clone https://github.com/nipreps/fmriprep.git fmriprep-3516
git -C fmriprep-3516 fetch origin refs/pull/3516/head
git -C fmriprep-3516 checkout FETCH_HEAD
fmriprep-docker [NORMAL ARGS] --patch fmriprep=$PWD/fmriprep-3516/fmriprep
```

@claraElk @HippocampusGirl Could you verify that this does not re-introduce the problems we were trying to fix in #3453?