### PR TITLE
MNT: Avoid using non-existing, deprecated contributor JSON files

### DIFF
--- a/.maint/update_zenodo.py
+++ b/.maint/update_zenodo.py
@@ -118,9 +118,9 @@ def loads_contributors(s):
     """Reformat contributors read from the Markdown table."""
     return [
         {
-            'affiliation': contributor['Affiliation'],
+            'affiliation': contributor['Affiliation'] if 'Affiliation' in contributor else None,
             'name': f'{contributor["Lastname"]}, {contributor["Name"]}',
-            'orcid': contributor['ORCID'],
+            'orcid': contributor['ORCID'] if 'ORCID' in contributor else None,
         }
         for contributor in loads_table_from_markdown(s)
     ]
@@ -132,18 +132,20 @@ if __name__ == '__main__':
     zenodo_file = Path('.zenodo.json')
     zenodo = json.loads(zenodo_file.read_text())
 
+    former = loads_contributors(Path('.maint/FORMER.md').read_text())
+
     creators = json.loads(Path('.maint/developers.json').read_text())
     zen_creators, miss_creators = sort_contributors(
         creators,
         data,
-        exclude=json.loads(Path('.maint/former.json').read_text()),
+        exclude=former,
         last=CREATORS_LAST,
     )
     contributors = loads_contributors(Path('.maint/CONTRIBUTORS.md').read_text())
     zen_contributors, miss_contributors = sort_contributors(
         contributors,
         data,
-        exclude=json.loads(Path('.maint/former.json').read_text()),
+        exclude=former,
         last=CONTRIBUTORS_LAST,
     )
     zenodo['creators'] = zen_creators


### PR DESCRIPTION
## Changes proposed in this pull request

Avoid using non-existing, deprecated contributor JSON files:
- `contributors.json` was transitioned to `CONTRIBUTORS.md` in commit 059b59c, but the file was not updated in `paper_author_list.py`, probably because it is not run with every release.
- Prefer using `FORMER.md` over `former.json` in line with the adopted latest convention.
- Add the necessary functions to read contributors from Markdown tables in `paper_author_list.py`.

Ensure that reading contributors from a Markdown file table does not fail if the "Affiliation" and "ORCID" data are missing, which is the case for the current record in `FORMER.md`. Use `None` if no data exists for those columns.

Read the `FORMER.md` file at a single place in `update_zenodo.py` and store its contents in a variable that can be reused.

## Documentation that should be reviewed

N/A