### PR TITLE
DOC: Include template metadata information when resampling BOLD to surface

### DIFF
--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -576,9 +576,8 @@ def init_wb_vol_surf_wf(
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
 The BOLD time-series were resampled onto the native surface of the subject
-using the "ribbon-constrained" method
+using the "ribbon-constrained" method{' and then dilated by 10 mm' * dilate}.
 """
-    workflow.__desc__ += ' and then dilated by 10 mm.' if dilate else '.'
 
     inputnode = pe.Node(
         niu.IdentityInterface(


### PR DESCRIPTION
Follow up on #3461 to include template information

<details>
<summary>Sampler boilerplate text</summary>

The BOLD time-series were resampled onto the left/right-symmetric template “fsLR” using the Connectome Workbench (Glasser et al. 2013). The BOLD time-series were resampled onto the native surface of the subject using the “ribbon-constrained” method and then dilated by 10 mm.Grayordinates files (Glasser et al. 2013) containing 91k samples were also generated with surface data transformed directly to fsLR space and subcortical data transformed to 2 mm resolution MNI152NLin6Asym space. The BOLD series was resampled to OpenNeuro Average (onavg) surface template [Feilong et al. (2024); TemplateFlow ID: onavg] using the Connectome Workbench. All resamplings can be performed with a single interpolation step by composing all the pertinent transformations (i.e. head-motion transform matrices, susceptibility distortion correction when available, and co-registrations to anatomical and output spaces). Gridded (volumetric) resamplings were performed using nitransforms, configured with cubic B-spline interpolation. Non-gridded (surface) resamplings were performed using the Connectome Workbench.Grayordinate “dscalar” files containing 91k samples were resampled onto fsLR using the Connectome Workbench (Glasser et al. 2013).

</details>