### PR TITLE
fix: pass actual t1w files to summary interface

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -382,7 +382,7 @@ It is released under the [CC0]\
         ])  # fmt:skip
     else:
         workflow.connect([
-            (src_file, summary, [('source_file', 't1w')]),
+            (bidssrc, summary, [('t1w', 't1w')]),
             (src_file, ds_report_summary, [('source_file', 'source_file')]),
             (src_file, ds_report_about, [('source_file', 'source_file')]),
         ])  # fmt:skip


### PR DESCRIPTION
Summary should receive the actual T1w files found, not a phony source file

Closes https://github.com/nipreps/fmriprep/issues/3530