### PR TITLE
chore: Prune Ubuntu environment before building docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,11 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Prune container
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache
+          docker system prune -af
+
       - name: Checkout repository
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Docker builds are suddenly failing for a lack of disk space. Trying out a suggestion in https://github.com/orgs/community/discussions/179725.