### PR TITLE
fix collect freesurfer  

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -397,10 +397,7 @@ It is released under the [CC0]\
         ]),
         (bidssrc, src_file, [('out_dict', 'bids_info')]),
         (src_file, bids_info, [('source_file', 'in_file')]),
-        (bids_info, create_fs_id, [
-            ('subject', 'subject_id'),
-            ('session', 'session_id'),
-        ]),
+        (bids_info, create_fs_id, [('subject', 'subject_id')]),
         (create_fs_id, anat_fit_wf, [('subject_id', 'inputnode.subject_id')]),
         # Reporting connections
         (inputnode, summary, [('subjects_dir', 'subjects_dir')]),
@@ -409,6 +406,11 @@ It is released under the [CC0]\
         (summary, ds_report_summary, [('out_report', 'in_file')]),
         (about, ds_report_about, [('out_report', 'in_file')]),
     ])  # fmt:skip
+
+    if config.workflow.subject_anatomical_reference == 'sessionwise':
+        workflow.connect([
+            (bids_info, create_fs_id, [('session', 'session_id')]),
+        ])  # fmt:skip
 
     # Set up the template iterator once, if used
     template_iterator_wf = None


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

Currently when preprocessing fMRI only dataset using precomputed sMRIPrep+freesurfer (`--fs-no-resume`)  and passing `--session-label yy`, the `fs_subject_id`  ends up being `sub-xx_ses-yy` using the fMRI selected session, and thus it picks files from that folder. I noticed it because my jobs was only pre-fetching with datalad `freesurfer/sub-xx` folder from a precomputed longitudinal freesurfer, but the pipeline tried using freesurfer files from `sub-xx_ses-yy` instead, which were broken symlinks. 

Not sure what is the best approach, but it seems that it should only try to get session-specific freesurfer when using `--subject-anatomical-reference sessionwise`, but it might require another case for `first-lex`. 

I am not 100% sure what are the outputs when you using this option:
- session-wise -> freesurfer/sub-xx_ses-yy/ ?
- first-lex -> freesurfer/sub-xx or same as sessionwise
- unbiased -> freesurfer/sub-xx I assume

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
