### PR TITLE
Set source_file in ds_report* nodes at resampling level

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -374,6 +374,7 @@ configured with cubic B-spline interpolation.
         for node in workflow.list_node_names():
             if node.split('.')[-1].startswith('ds_report'):
                 workflow.get_node(node).inputs.base_directory = fmriprep_dir
+                workflow.get_node(node).inputs.source_file = bold_file
         return workflow
 
     # Pass along BOLD reference as a source file for provenance


### PR DESCRIPTION
Closes #3586.

## Changes proposed in this pull request

- If `--level resampling` is used, pass the `bold_file` into any `ds_report` nodes as the `source_file`. This is done later in the workflow for `--level full`, but was missing for resampling level.