### PR TITLE
FIX: Improve FreeSurfer ID predictability

### DIFF
--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -112,11 +112,13 @@ class CreateFreeSurferID(SimpleInterface):
         )
         return runtime
 
+
 DEFAULT_MULTI_SOURCE_FILE_PATTERN = """\
 sub-{subject}[_ses-{session}][_task-{task}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]\
 [_run-{run}][_echo-{echo}][_part-{part}][_desc-{desc}]_{suffix<T[12]w|T1rho|T[12]map|T2star|FLAIR\
 |FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|bold>}{extension<.nii|.nii.gz>|.nii.gz}
 """
+
 
 def _create_multi_source_file(in_files, path_pattern=None):
     """

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -116,8 +116,8 @@ class CreateFreeSurferID(SimpleInterface):
 
 DEFAULT_MULTI_SOURCE_FILE_PATTERN = """\
 sub-{subject}[_ses-{session}][_task-{task}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]\
-[_run-{run}][_echo-{echo}][_part-{part}]_{suffix<T[12]w|T1rho|T[12]map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|bold>}\
-{extension<.nii|.nii.gz>|.nii.gz}\
+[_run-{run}][_echo-{echo}][_part-{part}][_desc-{desc}]_{suffix<T[12]w|T1rho|T[12]map|T2star|FLAIR\
+|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|bold>}{extension<.nii|.nii.gz>|.nii.gz}
 """
 
 def _create_multi_source_file(in_files, path_pattern=None):

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -116,7 +116,7 @@ class CreateFreeSurferID(SimpleInterface):
 DEFAULT_MULTI_SOURCE_FILE_PATTERN = """\
 sub-{subject}[_ses-{session}][_task-{task}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]\
 [_run-{run}][_echo-{echo}][_part-{part}][_desc-{desc}]_{suffix<T[12]w|T1rho|T[12]map|T2star|FLAIR\
-|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|bold>}{extension<.nii|.nii.gz>|.nii.gz}
+|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|bold>}{extension<.nii|.nii.gz>|.nii.gz}\
 """
 
 

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -69,7 +69,6 @@ class _BIDSSourceFileInputSpec(TraitedSpec):
         desc='BIDS information dictionary',
     )
     precomputed = traits.Dict({}, usedefault=True, desc='Precomputed BIDS information')
-    sessionwise = traits.Bool(False, usedefault=True, desc='Keep session information')
     anat_type = traits.Enum('t1w', 't2w', usedefault=True, desc='Anatomical reference type')
 
 
@@ -89,10 +88,7 @@ class BIDSSourceFile(SimpleInterface):
             self._results['source_file'] = _create_multi_source_file(src)
             return runtime
 
-        self._results['source_file'] = _create_multi_source_file(
-            src,
-            sessionwise=self.inputs.sessionwise,
-        )
+        self._results['source_file'] = _create_multi_source_file(src)
         return runtime
 
 

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -116,12 +116,15 @@ class CreateFreeSurferID(SimpleInterface):
         )
         return runtime
 
+DEFAULT_MULTI_SOURCE_FILE_PATTERN = """\
+sub-{subject}[_ses-{session}][_task-{task}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]\
+[_run-{run}][_echo-{echo}][_part-{part}]_{suffix<T[12]w|T1rho|T[12]map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|bold>}\
+{extension<.nii|.nii.gz>|.nii.gz}\
+"""
 
-def _create_multi_source_file(in_files, sessionwise=False):
+def _create_multi_source_file(in_files, path_pattern=None):
     """
     Create a generic source name from multiple input files.
-
-    If sessionwise is True, session information from the first file is retained in the name.
 
     Examples
     --------
@@ -131,34 +134,35 @@ def _create_multi_source_file(in_files, sessionwise=False):
     '/path/to/sub-045_T1w.nii.gz'
     >>> _create_multi_source_file([
     ...     '/path/to/sub-045_ses-1_run-1_T1w.nii.gz',
-    ...     '/path/to/sub-045_ses-1_run-2_T1w.nii.gz'],
-    ...     sessionwise=True)
+    ...     '/path/to/sub-045_ses-1_run-2_T1w.nii.gz'])
     '/path/to/sub-045_ses-1_T1w.nii.gz'
+    >>> _create_multi_source_file([
+    ...     '/path/to/sub-045_ses-1_task-rest_echo-1_bold.nii.gz',
+    ...     '/path/to/sub-045_ses-1_task-rest_echo-2_bold.nii.gz'])
+    '/path/to/sub-045_ses-1_task-rest_bold.nii.gz'
     """
-    import re
+    from functools import reduce
     from pathlib import Path
 
+    from bids.layout.utils import parse_file_entities
+    from bids.layout.writing import build_path
     from nipype.utils.filemanip import filename_to_list
 
-    if not isinstance(in_files, tuple | list):
+    in_files = filename_to_list(in_files)
+
+    if not in_files or not isinstance(in_files, list):
         return in_files
-    elif len(in_files) == 1:
+    if len(in_files) == 1:
         return in_files[0]
 
-    p = Path(filename_to_list(in_files)[0])
-    try:
-        subj = re.search(r'(?<=^sub-)[a-zA-Z0-9]*', p.name).group()
-        suffix = re.search(r'(?<=_)\w+(?=\.)', p.name).group()
-    except AttributeError as e:
-        raise AttributeError('Could not extract BIDS information') from e
+    all_entities = [parse_file_entities(f) for f in in_files]
+    shared_entities = dict(reduce(lambda a, b: a.items() & b.items(), all_entities))
 
-    prefix = f'sub-{subj}'
+    if path_pattern is None:
+        path_pattern = DEFAULT_MULTI_SOURCE_FILE_PATTERN
 
-    if sessionwise:
-        ses = re.search(r'(?<=_ses-)[a-zA-Z0-9]*', p.name)
-        if ses:
-            prefix += f'_ses-{ses.group()}'
-    return str(p.parent / f'{prefix}_{suffix}.nii.gz')
+    out_file = build_path(shared_entities, path_pattern)
+    return str(Path(in_files[0]).parent / out_file)
 
 
 def _create_fs_id(subject_id, session_id=None):

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -85,8 +85,6 @@ class BIDSSourceFile(SimpleInterface):
 
         if not src and self.inputs.precomputed.get(f'{self.inputs.anat_type}_preproc'):
             src = _ravel(self.inputs.bids_info['bold'])
-            self._results['source_file'] = _create_multi_source_file(src)
-            return runtime
 
         self._results['source_file'] = _create_multi_source_file(src)
         return runtime

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -95,6 +95,7 @@ class BIDSSourceFile(SimpleInterface):
 class _CreateFreeSurferIDInputSpec(TraitedSpec):
     subject_id = traits.Str(mandatory=True, desc='BIDS Subject ID')
     session_id = traits.Str(desc='BIDS session ID')
+    exclude_session = traits.Bool(False, usedefault=True, desc='Do not append session ID')
 
 
 class _CreateFreeSurferIDOutputSpec(TraitedSpec):
@@ -109,6 +110,7 @@ class CreateFreeSurferID(SimpleInterface):
         self._results['subject_id'] = _create_fs_id(
             self.inputs.subject_id,
             self.inputs.session_id or None,
+            exclude_session=self.inputs.exclude_session,
         )
         return runtime
 
@@ -161,7 +163,7 @@ def _create_multi_source_file(in_files, path_pattern=None):
     return str(Path(in_files[0]).parent / out_file)
 
 
-def _create_fs_id(subject_id, session_id=None):
+def _create_fs_id(subject_id, session_id=None, *, exclude_session=False):
     """
     Create FreeSurfer subject ID.
 
@@ -173,12 +175,14 @@ def _create_fs_id(subject_id, session_id=None):
     'sub-01'
     >>> _create_fs_id('01', 'pre')
     'sub-01_ses-pre'
+    >>> _create_fs_id('01', 'pre', exclude_session=True)
+    'sub-01'
     """
 
     if not subject_id.startswith('sub-'):
         subject_id = f'sub-{subject_id}'
 
-    if session_id:
+    if session_id and not exclude_session:
         ses_str = session_id
         if isinstance(session_id, list):
             from smriprep.utils.misc import stringify_sessions

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -154,7 +154,7 @@ def _create_multi_source_file(in_files, path_pattern=None):
         return in_files[0]
 
     all_entities = [parse_file_entities(f) for f in in_files]
-    shared_entities = dict(reduce(lambda a, b: a.items() & b.items(), all_entities))
+    shared_entities = reduce(lambda a, b: dict(a.items() & b.items()), all_entities)
 
     if path_pattern is None:
         path_pattern = DEFAULT_MULTI_SOURCE_FILE_PATTERN

--- a/fmriprep/interfaces/tests/test_bids.py
+++ b/fmriprep/interfaces/tests/test_bids.py
@@ -108,7 +108,7 @@ bids_infos_func = {
     [
         (bids_info_anat, bids_info_func, precomputed_infos)
         for bids_info_anat, precomputed_infos in bids_infos_anat
-        for func_case, bids_info_func in bids_infos_func.items()
+        for _, bids_info_func in bids_infos_func.items()
     ],
 )
 def test_BIDSSourceFile(bids_info_anat, bids_info_func, precomputed_infos):
@@ -123,11 +123,6 @@ def test_BIDSSourceFile(bids_info_anat, bids_info_func, precomputed_infos):
     results = interface.run()
 
     if precomputed_infos:
-        bold = (
-            'sub-01/func/sub-01_bold.nii.gz'
-            if isinstance(bids_info_func['bold'][0], list)
-            else 'sub-01/func/sub-01_task-rest_bold.nii.gz'
-        )
-        assert results.outputs.source_file == bold
+        assert results.outputs.source_file == 'sub-01/func/sub-01_task-rest_bold.nii.gz'
     else:
         assert results.outputs.source_file == bids_info_anat[anat_type][0]

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -303,7 +303,12 @@ It is released under the [CC0]\
         BIDSInfo(bids_dir=config.execution.bids_dir, bids_validate=False), name='bids_info'
     )
 
-    create_fs_id = pe.Node(CreateFreeSurferID(), name='create_fs_id')
+    create_fs_id = pe.Node(
+        CreateFreeSurferID(
+            exclude_session=config.workflow.subject_anatomical_reference != 'sessionwise',
+        ),
+        name='create_fs_id',
+    )
 
     summary = pe.Node(
         SubjectSummary(

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -295,10 +295,7 @@ It is released under the [CC0]\
     )
 
     src_file = pe.Node(
-        BIDSSourceFile(
-            precomputed=anatomical_cache,
-            sessionwise=config.workflow.subject_anatomical_reference == 'sessionwise',
-        ),
+        BIDSSourceFile(precomputed=anatomical_cache),
         name='source_anatomical',
     )
 


### PR DESCRIPTION
The intent after #3495 was encode as much information on how the anatomical template was formed into the FreeSurfer subject ID, but this introduced problems where the resulting FS ID could not be reused across a few cases:
- A new session was added after a previous run.
- Func-only processing leveraging precomputed derivatives from another session.

Starting this draft to think on how to cleanly address this in the future series.

Example 1
----------
Assume we have sub-01 with a single session, `pre`:

| --subject-anat-reference | FS ID (<25.2.x) | FS ID (25.2.x) | FS ID (26.0.x) |
|---------------------------|----------------|--|-------------------|
| sessionwise | n/a | sub-01_ses-pre | sub-01_ses-pre |
| first-lex | sub-01 | sub-01_ses-pre | sub-01 |
| unbiased | sub-01 | sub-01_ses-pre | sub-01 |

Now if a `post` session was added, the `post`'s anatomical will be used in `first-lex`.

| --subject-anat-reference | FS ID (<25.2.x) | FS ID (25.2.x) | FS ID (26.0.x) |
|---------------------------|----------------|--|-------------------|
| sessionwise | n/a | sub-01_ses-pre, sub-01_ses-post | sub-01_ses-pre, sub-01_ses-post |
| first-lex | sub-01 | sub-01_ses-post+pre | ? |
| unbiased | sub-01 | sub-01_ses-post+pre | ? |

IMO, sub-01 is misleading for both `first-lex` and `unbiased`, and only becomes hazier as additional sessions are added. Perhaps instead of changing the ID, some metadata (Sources) can be tied directly to the FreeSurfer subjects dir.

Example 2
----------

sub-Z has one `anat` and many `funcX` sessions. `anat` was processed with `--anat-only` and will be reused via `--derivatives`

| --subject-anat-reference | FS ID (<25.2.x) | FS ID (25.2.x) | FS ID (26.0.x) |
|---------------------------|----------------|--|-------------------|
| sessionwise | n/a | func session, no anat found | n/a |
| first-lex | sub-Z | sub-Z_anat+func1+.. | sub-Z |
| unbiased | sub-Z | sub-Z_anat+func1+.. | sub-Z |


Suggestions and additional examples are welcome and appreciated.