### PR TITLE
feat: add `--[no-]track-sessions` flag to lessen session label strictness

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -257,6 +257,13 @@ def _build_parser(**kwargs):
         'found, the behavior will be similar to "first-lex" for each session.',
     )
     g_bids.add_argument(
+        '--track-sessions',
+        action=BooleanOptionalAction,
+        default=True,
+        help='Track and append session IDs. If disabled, sessions will not be '
+        'tracked nor appended to FreeSurfer subject ID.',
+    )
+    g_bids.add_argument(
         '--bids-filter-file',
         dest='bids_filters',
         action='store',
@@ -978,6 +985,7 @@ applied."""
         subject_list,
         session_list,
         config.workflow.subject_anatomical_reference,
+        config.workflow.track_sessions,
     )
     config.execution.processing_groups = subject_session_list
     config.execution.participant_label = sorted(subject_list)
@@ -989,11 +997,16 @@ def create_processing_groups(
     subject_list: list,
     session_list: list | str | None,
     subject_anatomical_reference: str,
+    track_sessions: bool,
 ) -> list[tuple[str]]:
     """Generate a list of subject-session pairs to be processed."""
     from bids.layout import Query
 
     subject_session_list = []
+
+    sessionwise = subject_anatomical_reference == 'sessionwise'
+    if not sessionwise and not track_sessions:
+        config.loggers.cli.warning('Session information will not be preserved.')
 
     for subject in subject_list:
         sessions = (
@@ -1005,7 +1018,7 @@ def create_processing_groups(
             or None
         )
 
-        if subject_anatomical_reference == 'sessionwise':
+        if sessionwise:
             if sessions is None:
                 config.loggers.cli.warning(
                     '`--subject-anatomical-reference sessionwise` was requested, but no sessions '
@@ -1014,7 +1027,9 @@ def create_processing_groups(
                 subject_session_list.append((subject, None))
             else:
                 subject_session_list.extend((subject, session) for session in sessions)
+
+        # first-lex / unbiased
         else:
-            subject_session_list.append((subject, sessions))
+            subject_session_list.append((subject, sessions if track_sessions else None))
 
     return subject_session_list

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from .. import config
 
 if ty.TYPE_CHECKING:
-    from bids import BIDSLayout
+    pass
 
 
 def _build_parser(**kwargs):

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -28,9 +28,6 @@ from pathlib import Path
 
 from .. import config
 
-if ty.TYPE_CHECKING:
-    pass
-
 
 def _build_parser(**kwargs):
     """Build parser object.

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -23,7 +23,6 @@
 """Parser."""
 
 import sys
-import typing as ty
 from pathlib import Path
 
 from .. import config

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -979,57 +979,6 @@ applied."""
     if config.execution.participant_label is None:
         config.execution.participant_label = subject_list
 
-    session_list = config.execution.session_label or []
-    subject_session_list = create_processing_groups(
-        config.execution.layout,
-        subject_list,
-        session_list,
-        config.workflow.subject_anatomical_reference,
-        config.workflow.track_sessions,
-    )
-    config.execution.processing_groups = subject_session_list
     config.execution.participant_label = sorted(subject_list)
     config.workflow.skull_strip_template = config.workflow.skull_strip_template[0]
-
-
-def create_processing_groups(
-    layout: 'BIDSLayout',
-    subject_list: list,
-    session_list: list | str | None,
-    subject_anatomical_reference: str,
-    track_sessions: bool,
-) -> list[tuple[str]]:
-    """Generate a list of subject-session pairs to be processed."""
-    from bids.layout import Query
-
-    subject_session_list = []
-
-    sessionwise = subject_anatomical_reference == 'sessionwise'
-    if not sessionwise and not track_sessions:
-        config.loggers.cli.warning('Session information will not be preserved.')
-
-    for subject in subject_list:
-        sessions = (
-            layout.get_sessions(
-                scope='raw',
-                subject=subject,
-                session=session_list or Query.OPTIONAL,
-            )
-            or None
-        )
-
-        if sessionwise:
-            if sessions is None:
-                config.loggers.cli.warning(
-                    '`--subject-anatomical-reference sessionwise` was requested, but no sessions '
-                    f'found for subject {subject}... treating as single-session.'
-                )
-                subject_session_list.append((subject, None))
-            else:
-                subject_session_list.extend((subject, session) for session in sessions)
-
-        # first-lex / unbiased
-        else:
-            subject_session_list.append((subject, sessions if track_sessions else None))
-
-    return subject_session_list
+    config._create_processing_groups()

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -631,6 +631,8 @@ class workflow(_Config):
     `first-lex` will use the first image in lexicographical order, `unbiased` will
     construct an unbiased template from all available images (previously --longitudinal),
     and `sessionwise` will independently process each session."""
+    track_sessions = True
+    """Propagate sessions within each sub-workflow."""
     use_aroma = None
     """Run ICA-:abbr:`AROMA (automatic removal of motion artifacts)`."""
     use_bbr = None

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -892,3 +892,81 @@ def _deserialize_pg(value: list[str]) -> list[tuple[str, list[str] | None]]:
             ses = ses.removeprefix('ses-').split(',')
         deserial.append((sub, ses or None))
     return deserial
+
+
+def _create_processing_groups() -> list[tuple[str, str | list[str] | None]]:
+    """
+    Generate subject/session groupings for processing.
+
+    This function determines how BIDS subjects and sessions should be grouped
+    for downstream processing, based on workflow configuration.
+
+    The grouping behavior depends on two workflow settings:
+
+    - ``workflow.subject_anatomical_reference == "sessionwise"``
+        Each (subject, session) pair is processed independently.
+        If a subject has no sessions, it is treated as a single-session subject.
+
+    - ``workflow.track_sessions == True``
+        Sessions are preserved and returned as a list associated with the subject.
+        This produces session-aware derivatives, such as sub-X-ses-Y FreeSurfer IDs.
+
+    - Otherwise
+        Session information is discarded and subjects are processed without
+        session differentiation.
+
+    Returns
+    -------
+    list
+        A list of processing groups. Each element is a tuple and can consist of:
+
+        - (subject, session) if operating session-wise
+        - (subject, [sessions]) if tracking sessions
+        - (subject, None) if sessions are ignored
+
+    Raises
+    ------
+    RuntimeError
+        If the BIDS layout has not been initialized.
+    """
+    layout = execution.layout
+    if layout is None:
+        raise RuntimeError('BIDS Layout is not initialized. Cannot create processing groups.')
+
+    from bids.layout import Query
+
+    sessionwise = workflow.subject_anatomical_reference == 'sessionwise'
+    track_sessions = workflow.track_sessions
+
+    if not sessionwise and not track_sessions:
+        loggers.cli.warning('Session information will not be preserved.')
+
+    subject_session_list: list[tuple[str, str | list[str] | None]] = []
+
+    for subject in execution.participant_label:
+        sessions = (
+            layout.get_sessions(
+                scope='raw',
+                subject=subject,
+                session=execution.session_label or Query.OPTIONAL,
+            )
+            or None
+        )
+
+        if sessionwise:
+            if not sessions:
+                loggers.cli.warning(
+                    '`--subject-anatomical-reference sessionwise` was requested, but '
+                    f'no sessions were found for subject {subject}. Treating as '
+                    'single-session.'
+                )
+                subject_session_list.append((subject, None))
+            else:
+                subject_session_list.extend((subject, ses) for ses in sessions)
+            continue
+
+        # Non-sessionwise processing
+        subject_session_list.append((subject, sessions if track_sessions else None))
+
+    execution.processing_groups = subject_session_list
+    return subject_session_list

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -265,6 +265,7 @@ It is released under the [CC0]\
 
     spaces = config.workflow.spaces
     msm_sulc = config.workflow.run_msmsulc
+    sessionwise = config.workflow.subject_anatomical_reference == 'sessionwise'
 
     anatomical_cache = {}
     if config.execution.derivatives:
@@ -297,7 +298,7 @@ It is released under the [CC0]\
     src_file = pe.Node(
         BIDSSourceFile(
             precomputed=anatomical_cache,
-            sessionwise=config.workflow.subject_anatomical_reference == 'sessionwise',
+            sessionwise=sessionwise,
         ),
         name='source_anatomical',
     )
@@ -409,6 +410,9 @@ It is released under the [CC0]\
         (summary, ds_report_summary, [('out_report', 'in_file')]),
         (about, ds_report_about, [('out_report', 'in_file')]),
     ])  # fmt:skip
+
+    if not config.workflow.track_sessions and not sessionwise:
+        workflow.disconnect(bids_info, 'session', create_fs_id, 'session_id')
 
     # Set up the template iterator once, if used
     template_iterator_wf = None

--- a/fmriprep/workflows/bold/tests/test_base.py
+++ b/fmriprep/workflows/bold/tests/test_base.py
@@ -8,7 +8,7 @@ from niworkflows.utils.testing import generate_bids_skeleton
 
 from .... import config
 from ...tests import mock_config
-from ...tests.test_base import BASE_LAYOUT
+from ...tests.layouts import get_layout
 from ..base import init_bold_wf
 
 
@@ -27,7 +27,7 @@ def _quiet_logger():
 def bids_root(tmp_path_factory):
     base = tmp_path_factory.mktemp('boldbase')
     bids_dir = base / 'bids'
-    generate_bids_skeleton(bids_dir, BASE_LAYOUT)
+    generate_bids_skeleton(bids_dir, get_layout('no_session'))
     return bids_dir
 
 

--- a/fmriprep/workflows/bold/tests/test_fit.py
+++ b/fmriprep/workflows/bold/tests/test_fit.py
@@ -8,7 +8,7 @@ from niworkflows.utils.testing import generate_bids_skeleton
 
 from .... import config
 from ...tests import mock_config
-from ...tests.test_base import BASE_LAYOUT
+from ...tests.layouts import get_layout
 from ..fit import init_bold_fit_wf, init_bold_native_wf
 
 
@@ -27,7 +27,7 @@ def _quiet_logger():
 def bids_root(tmp_path_factory):
     base = tmp_path_factory.mktemp('boldfit')
     bids_dir = base / 'bids'
-    generate_bids_skeleton(bids_dir, BASE_LAYOUT)
+    generate_bids_skeleton(bids_dir, get_layout('no_session'))
     return bids_dir
 
 
@@ -122,6 +122,7 @@ def test_bold_fit_precomputes(
         precomputed['transforms']['boldref2fmap'] = dummy_affine
 
     with mock_config(bids_dir=bids_root):
+        config.workflow.bold2anat_init = 't1w'
         wf = init_bold_fit_wf(
             bold_series=bold_series,
             precomputed=precomputed,

--- a/fmriprep/workflows/tests/layouts.py
+++ b/fmriprep/workflows/tests/layouts.py
@@ -1,130 +1,145 @@
-from copy import deepcopy
+def _make_anat():
+    return [
+        {'run': 1, 'suffix': 'T1w'},
+        {'run': 2, 'suffix': 'T1w'},
+        {'suffix': 'T2w'},
+    ]
 
 
-_anat = [
-    {'run': 1, 'suffix': 'T1w'},
-    {'run': 2, 'suffix': 'T1w'},
-    {'suffix': 'T2w'},
-]
+def _make_func():
+    return [
+        *(
+            {
+                'task': 'rest',
+                'run': i,
+                'suffix': suffix,
+                'metadata': {
+                    'RepetitionTime': 2.0,
+                    'PhaseEncodingDirection': 'j',
+                    'TotalReadoutTime': 0.6,
+                    'EchoTime': 0.03,
+                    'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
+                },
+            }
+            for suffix in ('bold', 'sbref')
+            for i in range(1, 3)
+        ),
+        *(
+            {
+                'task': 'nback',
+                'echo': i,
+                'suffix': 'bold',
+                'metadata': {
+                    'RepetitionTime': 2.0,
+                    'PhaseEncodingDirection': 'j',
+                    'TotalReadoutTime': 0.6,
+                    'EchoTime': 0.015 * i,
+                    'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
+                },
+            }
+            for i in range(1, 4)
+        ),
+    ]
 
-_func = [
-    *(
+
+def _make_fmap():
+    return [
+        {'suffix': 'phasediff', 'metadata': {'EchoTime1': 0.005, 'EchoTime2': 0.007}},
+        {'suffix': 'magnitude1', 'metadata': {'EchoTime': 0.005}},
         {
-            'task': 'rest',
-            'run': i,
-            'suffix': suffix,
-            'metadata': {
-                'RepetitionTime': 2.0,
-                'PhaseEncodingDirection': 'j',
-                'TotalReadoutTime': 0.6,
-                'EchoTime': 0.03,
-                'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
-            },
-        }
-        for suffix in ('bold', 'sbref')
-        for i in range(1, 3)
-    ),
-    *(
-        {
-            'task': 'nback',
-            'echo': i,
-            'suffix': 'bold',
-            'metadata': {
-                'RepetitionTime': 2.0,
-                'PhaseEncodingDirection': 'j',
-                'TotalReadoutTime': 0.6,
-                'EchoTime': 0.015 * i,
-                'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
-            },
-        }
-        for i in range(1, 4)
-    ),
-]
-
-_fmap = [
-    {'suffix': 'phasediff', 'metadata': {'EchoTime1': 0.005, 'EchoTime2': 0.007}},
-    {'suffix': 'magnitude1', 'metadata': {'EchoTime': 0.005}},
-    {
-        'suffix': 'epi',
-        'dir': 'PA',
-        'metadata': {'PhaseEncodingDirection': 'j', 'TotalReadoutTime': 0.6},
-    },
-    {
-        'suffix': 'epi',
-        'dir': 'AP',
-        'metadata': {'PhaseEncodingDirection': 'j-', 'TotalReadoutTime': 0.6},
-    },
-]
-
-_no_session = {
-    '01': {
-        'anat': _anat,
-        'func': _func,
-        'fmap': _fmap,
-    },
-}
-
-_single_session = {
-    '01': [
-        {
-            'session': 'pre',
-            'anat': _anat,
-            'func': _func,
-            'fmap': _fmap,
-        }
-    ],
-}
-
-_homogeneous_sessions = {
-    '01': [
-        {
-            'session': 'pre',
-            'anat': _anat,
-            'func': _func,
-            'fmap': _fmap,
+            'suffix': 'epi',
+            'dir': 'PA',
+            'metadata': {'PhaseEncodingDirection': 'j', 'TotalReadoutTime': 0.6},
         },
         {
-            'session': 'post',
-            'anat': _anat,
-            'func': _func,
-            'fmap': _fmap,
+            'suffix': 'epi',
+            'dir': 'AP',
+            'metadata': {'PhaseEncodingDirection': 'j-', 'TotalReadoutTime': 0.6},
         },
     ]
-}
 
-_heterogeneous_sessions = {
-    '01': [
-        {
-            'session': 'anat',
-            'anat': {'suffix': 'T1w'},
-        },
-        {
-            'session': 'fmri',
-            'func': [
-                {
-                    'task': 'rest',
-                    'suffix': 'bold',
-                    'metadata': {
-                        'RepetitionTime': 2.0,
-                        'PhaseEncodingDirection': 'j',
-                        'TotalReadoutTime': 0.6,
-                    },
-                }
-            ],
-        },
-    ]
-}
 
-LAYOUTS = {
-    'no_session': _no_session,
-    'single_session': _single_session,
-    'homogeneous_sessions': _homogeneous_sessions,
-    'heterogeneous_sessions': _heterogeneous_sessions,
+def _make_no_session():
+    return {
+        '01': {
+            'anat': _make_anat(),
+            'func': _make_func(),
+            'fmap': _make_fmap(),
+        },
+    }
+
+
+def _make_single_session():
+    return {
+        '01': [
+            {
+                'session': 'pre',
+                'anat': _make_anat(),
+                'func': _make_func(),
+                'fmap': _make_fmap(),
+            }
+        ],
+    }
+
+
+def _make_homogeneous_sessions():
+    return {
+        '01': [
+            {
+                'session': 'pre',
+                'anat': _make_anat(),
+                'func': _make_func(),
+                'fmap': _make_fmap(),
+            },
+            {
+                'session': 'post',
+                'anat': _make_anat(),
+                'func': _make_func(),
+                'fmap': _make_fmap(),
+            },
+        ]
+    }
+
+
+def _make_heterogeneous_sessions():
+    return {
+        '01': [
+            {
+                'session': 'anat',
+                'anat': {'suffix': 'T1w'},
+            },
+            {
+                'session': 'fmri',
+                'func': [
+                    {
+                        'task': 'rest',
+                        'suffix': 'bold',
+                        'metadata': {
+                            'RepetitionTime': 2.0,
+                            'PhaseEncodingDirection': 'j',
+                            'TotalReadoutTime': 0.6,
+                        },
+                    }
+                ],
+            },
+        ]
+    }
+
+
+_LAYOUT_FACTORIES = {
+    'no_session': _make_no_session,
+    'single_session': _make_single_session,
+    'homogeneous_sessions': _make_homogeneous_sessions,
+    'heterogeneous_sessions': _make_heterogeneous_sessions,
 }
 
 
 def get_layout(layout_id: str):
-    """Get a layout spec by ID."""
-    return deepcopy(LAYOUTS[layout_id])
+    """Get a fresh layout spec by ID."""
+    try:
+        return _LAYOUT_FACTORIES[layout_id]()
+    except KeyError:
+        raise ValueError(f'Unknown layout: {layout_id!r}. Choose from {list(_LAYOUT_FACTORIES)}')
+
 
 __all__ = ['get_layout']

--- a/fmriprep/workflows/tests/layouts.py
+++ b/fmriprep/workflows/tests/layouts.py
@@ -138,8 +138,10 @@ def get_layout(layout_id: str):
     """Get a fresh layout spec by ID."""
     try:
         return _LAYOUT_FACTORIES[layout_id]()
-    except KeyError:
-        raise ValueError(f'Unknown layout: {layout_id!r}. Choose from {list(_LAYOUT_FACTORIES)}')
+    except KeyError as exc:
+        raise ValueError(
+            f'Unknown layout: {layout_id!r}. Choose from {list(_LAYOUT_FACTORIES)}'
+        ) from exc
 
 
 __all__ = ['get_layout']

--- a/fmriprep/workflows/tests/layouts.py
+++ b/fmriprep/workflows/tests/layouts.py
@@ -1,0 +1,130 @@
+from copy import deepcopy
+
+
+_anat = [
+    {'run': 1, 'suffix': 'T1w'},
+    {'run': 2, 'suffix': 'T1w'},
+    {'suffix': 'T2w'},
+]
+
+_func = [
+    *(
+        {
+            'task': 'rest',
+            'run': i,
+            'suffix': suffix,
+            'metadata': {
+                'RepetitionTime': 2.0,
+                'PhaseEncodingDirection': 'j',
+                'TotalReadoutTime': 0.6,
+                'EchoTime': 0.03,
+                'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
+            },
+        }
+        for suffix in ('bold', 'sbref')
+        for i in range(1, 3)
+    ),
+    *(
+        {
+            'task': 'nback',
+            'echo': i,
+            'suffix': 'bold',
+            'metadata': {
+                'RepetitionTime': 2.0,
+                'PhaseEncodingDirection': 'j',
+                'TotalReadoutTime': 0.6,
+                'EchoTime': 0.015 * i,
+                'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
+            },
+        }
+        for i in range(1, 4)
+    ),
+]
+
+_fmap = [
+    {'suffix': 'phasediff', 'metadata': {'EchoTime1': 0.005, 'EchoTime2': 0.007}},
+    {'suffix': 'magnitude1', 'metadata': {'EchoTime': 0.005}},
+    {
+        'suffix': 'epi',
+        'dir': 'PA',
+        'metadata': {'PhaseEncodingDirection': 'j', 'TotalReadoutTime': 0.6},
+    },
+    {
+        'suffix': 'epi',
+        'dir': 'AP',
+        'metadata': {'PhaseEncodingDirection': 'j-', 'TotalReadoutTime': 0.6},
+    },
+]
+
+_no_session = {
+    '01': {
+        'anat': _anat,
+        'func': _func,
+        'fmap': _fmap,
+    },
+}
+
+_single_session = {
+    '01': [
+        {
+            'session': 'pre',
+            'anat': _anat,
+            'func': _func,
+            'fmap': _fmap,
+        }
+    ],
+}
+
+_homogeneous_sessions = {
+    '01': [
+        {
+            'session': 'pre',
+            'anat': _anat,
+            'func': _func,
+            'fmap': _fmap,
+        },
+        {
+            'session': 'post',
+            'anat': _anat,
+            'func': _func,
+            'fmap': _fmap,
+        },
+    ]
+}
+
+_heterogeneous_sessions = {
+    '01': [
+        {
+            'session': 'anat',
+            'anat': {'suffix': 'T1w'},
+        },
+        {
+            'session': 'fmri',
+            'func': [
+                {
+                    'task': 'rest',
+                    'suffix': 'bold',
+                    'metadata': {
+                        'RepetitionTime': 2.0,
+                        'PhaseEncodingDirection': 'j',
+                        'TotalReadoutTime': 0.6,
+                    },
+                }
+            ],
+        },
+    ]
+}
+
+LAYOUTS = {
+    'no_session': _no_session,
+    'single_session': _single_session,
+    'homogeneous_sessions': _homogeneous_sessions,
+    'heterogeneous_sessions': _heterogeneous_sessions,
+}
+
+
+def get_layout(layout_id: str):
+    """Get a layout spec by ID."""
+    return deepcopy(LAYOUTS[layout_id])
+
+__all__ = ['get_layout']

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -35,7 +35,7 @@ def _reset_sdcflows_registry():
 
 @pytest.fixture(scope='module')
 def bids_root(tmp_path_factory):
-    """Default fixture using BASE_LAYOUT."""
+    """Default fixture using the "no_session" layout."""
     return _make_bids_root(tmp_path_factory, 'no_session')
 
 
@@ -352,7 +352,7 @@ def test_fmriprep_wf_builds(bids_root_factory, layout_id, subject_anatomical_ref
 
 
 def test_fmriprep_wf_heterogeneous_sessions(bids_root_factory):
-    """Test on a heterogenous sessions layout, and test track_sessions behavior"""
+    """Test on a heterogeneous sessions layout, and test track_sessions behavior"""
     bids_dir = bids_root_factory('heterogeneous_sessions')
     with mock_config(bids_dir=bids_dir):
         config.workflow.track_sessions = True

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -34,33 +34,40 @@ def _reset_sdcflows_registry():
 
 
 @pytest.fixture(scope='module')
-def bids_root(tmp_path_factory):
+def _layout_cache():
+    """Cache layouts across tests to avoid regenerating BIDS directories."""
+    return {}
+
+
+@pytest.fixture(scope='module')
+def bids_root(tmp_path_factory, _layout_cache):
     """Default fixture using the "no_session" layout."""
-    return _make_bids_root(tmp_path_factory, 'no_session')
+    return _make_bids_root(tmp_path_factory, 'no_session', _layout_cache)
 
 
-def _make_bids_root(tmp_path_factory, layout_id: str):
+def _make_bids_root(tmp_path_factory, layout_id: str, cache: dict):
     """Helper to create a BIDS directory from a layout spec."""
+    if layout_id in cache:
+        return cache[layout_id]
+
     base = tmp_path_factory.mktemp('base')
     bids_dir = base / layout_id
-    if bids_dir.exists():
-        return bids_dir
 
-    # Otherwise generate once
     layout = get_layout(layout_id)
     generate_bids_skeleton(bids_dir, layout)
     img = nb.Nifti1Image(np.zeros((10, 10, 10, 10)), np.eye(4))
     for bold_path in bids_dir.glob('sub-01/**/*.nii.gz'):
         img.to_filename(bold_path)
+    cache[layout_id] = bids_dir
     return bids_dir
 
 
 @pytest.fixture(scope='module')
-def bids_root_factory(tmp_path_factory):
+def bids_root_factory(tmp_path_factory, _layout_cache):
     """Factory fixture — call with any layout to get a BIDS root."""
 
     def _factory(layout):
-        return _make_bids_root(tmp_path_factory, layout)
+        return _make_bids_root(tmp_path_factory, layout, _layout_cache)
 
     return _factory
 

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -11,9 +11,9 @@ from sdcflows.fieldmaps import clear_registry
 from sdcflows.utils.wrangler import find_estimators
 
 from ... import config
-from .layouts import get_layout
 from ..base import get_estimator, init_fmriprep_wf
 from ..tests import mock_config
+from .layouts import get_layout
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -58,8 +58,10 @@ def _make_bids_root(tmp_path_factory, layout_id: str):
 @pytest.fixture(scope='module')
 def bids_root_factory(tmp_path_factory):
     """Factory fixture — call with any layout to get a BIDS root."""
+
     def _factory(layout):
         return _make_bids_root(tmp_path_factory, layout)
+
     return _factory
 
 
@@ -338,3 +340,29 @@ def test_get_estimator_multiple_b0fields(tmp_path):
     # Always get an iterable; don't care if it's a list or tuple
     assert get_estimator(layout, bold_files[0]) == ['epi', 'phasediff']
     assert get_estimator(layout, bold_files[1]) == ('epi',)
+
+
+@pytest.mark.parametrize('layout_id', ['no_session', 'single_session', 'homogeneous_sessions'])
+@pytest.mark.parametrize('subject_anatomical_reference', ['first-lex', 'sessionwise', 'unbiased'])
+def test_fmriprep_wf_builds(bids_root_factory, layout_id, subject_anatomical_reference):
+    bids_dir = bids_root_factory(layout_id)
+    with mock_config(bids_dir=bids_dir):
+        config.workflow.subject_anatomical_reference = subject_anatomical_reference
+        assert init_fmriprep_wf()
+
+
+def test_fmriprep_wf_heterogeneous_sessions(bids_root_factory):
+    """Test on a heterogenous sessions layout, and test track_sessions behavior"""
+    bids_dir = bids_root_factory('heterogeneous_sessions')
+    with mock_config(bids_dir=bids_dir):
+        config.workflow.track_sessions = True
+        procs = config._create_processing_groups()
+        assert procs == [('01', ['anat', 'fmri'])]
+        wf = init_fmriprep_wf()
+        assert wf.get_node('sub_01_ses_anat-fmri_wf')
+
+        config.workflow.track_sessions = False
+        procs = config._create_processing_groups()
+        assert procs == [('01', None)]
+        wf = init_fmriprep_wf()
+        assert wf.get_node('sub_01_wf')

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
 
@@ -12,65 +11,9 @@ from sdcflows.fieldmaps import clear_registry
 from sdcflows.utils.wrangler import find_estimators
 
 from ... import config
+from .layouts import get_layout
 from ..base import get_estimator, init_fmriprep_wf
 from ..tests import mock_config
-
-BASE_LAYOUT = {
-    '01': {
-        'anat': [
-            {'run': 1, 'suffix': 'T1w'},
-            {'run': 2, 'suffix': 'T1w'},
-            {'suffix': 'T2w'},
-        ],
-        'func': [
-            *(
-                {
-                    'task': 'rest',
-                    'run': i,
-                    'suffix': suffix,
-                    'metadata': {
-                        'RepetitionTime': 2.0,
-                        'PhaseEncodingDirection': 'j',
-                        'TotalReadoutTime': 0.6,
-                        'EchoTime': 0.03,
-                        'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
-                    },
-                }
-                for suffix in ('bold', 'sbref')
-                for i in range(1, 3)
-            ),
-            *(
-                {
-                    'task': 'nback',
-                    'echo': i,
-                    'suffix': 'bold',
-                    'metadata': {
-                        'RepetitionTime': 2.0,
-                        'PhaseEncodingDirection': 'j',
-                        'TotalReadoutTime': 0.6,
-                        'EchoTime': 0.015 * i,
-                        'SliceTiming': [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
-                    },
-                }
-                for i in range(1, 4)
-            ),
-        ],
-        'fmap': [
-            {'suffix': 'phasediff', 'metadata': {'EchoTime1': 0.005, 'EchoTime2': 0.007}},
-            {'suffix': 'magnitude1', 'metadata': {'EchoTime': 0.005}},
-            {
-                'suffix': 'epi',
-                'dir': 'PA',
-                'metadata': {'PhaseEncodingDirection': 'j', 'TotalReadoutTime': 0.6},
-            },
-            {
-                'suffix': 'epi',
-                'dir': 'AP',
-                'metadata': {'PhaseEncodingDirection': 'j-', 'TotalReadoutTime': 0.6},
-            },
-        ],
-    },
-}
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -92,16 +35,32 @@ def _reset_sdcflows_registry():
 
 @pytest.fixture(scope='module')
 def bids_root(tmp_path_factory):
+    """Default fixture using BASE_LAYOUT."""
+    return _make_bids_root(tmp_path_factory, 'no_session')
+
+
+def _make_bids_root(tmp_path_factory, layout_id: str):
+    """Helper to create a BIDS directory from a layout spec."""
     base = tmp_path_factory.mktemp('base')
-    bids_dir = base / 'bids'
-    generate_bids_skeleton(bids_dir, BASE_LAYOUT)
+    bids_dir = base / layout_id
+    if bids_dir.exists():
+        return bids_dir
 
+    # Otherwise generate once
+    layout = get_layout(layout_id)
+    generate_bids_skeleton(bids_dir, layout)
     img = nb.Nifti1Image(np.zeros((10, 10, 10, 10)), np.eye(4))
-
-    for bold_path in bids_dir.glob('sub-01/*/*.nii.gz'):
+    for bold_path in bids_dir.glob('sub-01/**/*.nii.gz'):
         img.to_filename(bold_path)
-
     return bids_dir
+
+
+@pytest.fixture(scope='module')
+def bids_root_factory(tmp_path_factory):
+    """Factory fixture — call with any layout to get a BIDS root."""
+    def _factory(layout):
+        return _make_bids_root(tmp_path_factory, layout)
+    return _factory
 
 
 def _make_params(
@@ -117,7 +76,6 @@ def _make_params(
     freesurfer: bool = True,
     ignore: list[str] | None = None,
     force: list[str] | None = None,
-    subject_anatomical_reference: str = 'first-lex',
     bids_filters: dict | None = None,
 ):
     if ignore is None:
@@ -139,7 +97,6 @@ def _make_params(
         freesurfer,
         ignore,
         force,
-        subject_anatomical_reference,
         bids_filters,
     )
 
@@ -160,7 +117,6 @@ def _make_params(
         'freesurfer',
         'ignore',
         'force',
-        'subject_anatomical_reference',
         'bids_filters',
     ),
     [
@@ -192,13 +148,10 @@ def _make_params(
         # _make_params(freesurfer=False, bold2anat_init="header", force=['no-bbr']),
         # Regression test for gh-3154:
         _make_params(bids_filters={'sbref': {'suffix': 'sbref'}}),
-        _make_params(subject_anatomical_reference='unbiased'),
-        _make_params(subject_anatomical_reference='sessionwise'),
     ],
 )
 def test_init_fmriprep_wf(
     bids_root: Path,
-    tmp_path: Path,
     level: str,
     anat_only: bool,
     bold2anat_init: str,
@@ -213,7 +166,6 @@ def test_init_fmriprep_wf(
     freesurfer: bool,
     ignore: list[str],
     force: list[str],
-    subject_anatomical_reference: str,
     bids_filters: dict,
 ):
     with mock_config(bids_dir=bids_root):
@@ -230,6 +182,7 @@ def test_init_fmriprep_wf(
         config.workflow.run_reconall = freesurfer
         config.workflow.ignore = ignore
         config.workflow.force = force
+        config.workflow.use_syn_sdc = use_syn_sdc
         with patch.dict('fmriprep.config.execution.bids_filters', bids_filters):
             wf = init_fmriprep_wf()
 
@@ -239,7 +192,7 @@ def test_init_fmriprep_wf(
 def test_init_fmriprep_wf_sanitize_fmaps(tmp_path):
     bids_dir = tmp_path / 'bids'
 
-    spec = deepcopy(BASE_LAYOUT)
+    spec = get_layout('no_session')
     spec['01']['func'][0]['metadata']['B0FieldSource'] = 'epi<<run1>>'
     spec['01']['fmap'][2]['metadata']['B0FieldIdentifier'] = 'epi<<run1>>'
     spec['01']['fmap'][3]['metadata']['B0FieldIdentifier'] = 'epi<<run1>>'
@@ -258,7 +211,7 @@ def test_init_fmriprep_wf_sanitize_fmaps(tmp_path):
 def test_init_fmriprep_wf_sanitize_plus(tmp_path):
     bids_dir = tmp_path / 'bids'
 
-    spec = deepcopy(BASE_LAYOUT)
+    spec = get_layout('no_session')
     spec['01']['func'][0]['acquisition'] = 'mb4+pf68th'
     spec['01']['anat'][0]['acquisition'] = 'memprage+rms'
     spec['01']['anat'][1]['acquisition'] = 'memprage'
@@ -280,7 +233,7 @@ def test_get_estimator_none(tmp_path):
     bids_dir = tmp_path / 'bids'
 
     # No IntendedFors/B0Fields
-    generate_bids_skeleton(bids_dir, BASE_LAYOUT)
+    generate_bids_skeleton(bids_dir, get_layout('no_session'))
     layout = bids.BIDSLayout(bids_dir)
     bold_files = sorted(
         layout.get(suffix='bold', task='rest', extension='.nii.gz', return_type='file')
@@ -294,7 +247,7 @@ def test_get_estimator_b0field_and_intendedfor(tmp_path):
     bids_dir = tmp_path / 'bids'
 
     # Set B0FieldSource for run 1
-    spec = deepcopy(BASE_LAYOUT)
+    spec = get_layout('no_session')
     spec['01']['func'][0]['metadata']['B0FieldSource'] = 'epi'
     spec['01']['fmap'][2]['metadata']['B0FieldIdentifier'] = 'epi'
     spec['01']['fmap'][3]['metadata']['B0FieldIdentifier'] = 'epi'
@@ -319,7 +272,7 @@ def test_get_estimator_intendedfor(tmp_path):
     bids_dir = tmp_path / 'bids'
 
     # Set B0FieldSource for run 1
-    spec = deepcopy(BASE_LAYOUT)
+    spec = get_layout('no_session')
     spec['01']['fmap'][0]['metadata']['IntendedFor'] = 'func/sub-01_task-rest_run-2_bold.nii.gz'
 
     generate_bids_skeleton(bids_dir, spec)
@@ -337,7 +290,7 @@ def test_get_estimator_overlapping_specs(tmp_path):
     bids_dir = tmp_path / 'bids'
 
     # Set B0FieldSource for both runs
-    spec = deepcopy(BASE_LAYOUT)
+    spec = get_layout('no_session')
     spec['01']['func'][0]['metadata']['B0FieldSource'] = 'epi'
     spec['01']['func'][1]['metadata']['B0FieldSource'] = 'epi'
     spec['01']['fmap'][2]['metadata']['B0FieldIdentifier'] = 'epi'
@@ -366,7 +319,7 @@ def test_get_estimator_multiple_b0fields(tmp_path):
     bids_dir = tmp_path / 'bids'
 
     # Set B0FieldSource for both runs
-    spec = deepcopy(BASE_LAYOUT)
+    spec = get_layout('no_session')
     spec['01']['func'][0]['metadata']['B0FieldSource'] = ('epi', 'phasediff')
     spec['01']['func'][1]['metadata']['B0FieldSource'] = 'epi'
     spec['01']['fmap'][0]['metadata']['B0FieldIdentifier'] = 'phasediff'

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -355,6 +355,7 @@ def test_fmriprep_wf_heterogeneous_sessions(bids_root_factory):
     """Test on a heterogeneous sessions layout, and test track_sessions behavior"""
     bids_dir = bids_root_factory('heterogeneous_sessions')
     with mock_config(bids_dir=bids_dir):
+        config.workflow.bold2anat_init = 't1w'
         config.workflow.track_sessions = True
         procs = config._create_processing_groups()
         assert procs == [('01', ['anat', 'fmri'])]

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -348,6 +348,7 @@ def test_fmriprep_wf_builds(bids_root_factory, layout_id, subject_anatomical_ref
     bids_dir = bids_root_factory(layout_id)
     with mock_config(bids_dir=bids_dir):
         config.workflow.subject_anatomical_reference = subject_anatomical_reference
+        config._create_processing_groups()
         assert init_fmriprep_wf()
 
 


### PR DESCRIPTION
Addresses #3613 #3601 #3581 

Supersedes #3606 

Adds a new command line option `--track-sessions` (and to disable, `--no-track-sessions`) to explicitly control the use of session ID within the workflow.

If enabled, requested or found session(s) propagated:
working directory -> `fmriprep_25_2_wf/sub_01_ses_pre_wf/`
FreeSurfer ID -> sub-01_ses-pre
Constrained filtering -> filtering by `session` is not allowed

If disabled, requested or found session(s) omitted:
working directory -> `fmriprep_25_2_wf/sub_01_wf/`
FreeSurfer ID -> sub-01
Free filtering