### PR TITLE
FIX: Reuse fewer config options when using `--config-file`

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -797,11 +797,7 @@ def parse_args(args=None, namespace=None):
     parser = _build_parser()
     opts = parser.parse_args(args, namespace)
 
-    if opts.config_file:
-        skip = {} if opts.reports_only else {'execution': ('run_uuid',)}
-        config.load(opts.config_file, skip=skip, init=False)
-        config.loggers.cli.info(f'Loaded previous configuration file {opts.config_file}')
-
+    # TODO: Deprecate
     if opts.longitudinal:
         opts.subject_anatomical_reference = 'unbiased'
         msg = (
@@ -809,6 +805,14 @@ def parse_args(args=None, namespace=None):
             '`--subject-anatomical-reference unbiased` instead.'
         )
         config.loggers.cli.warning(msg)
+
+    if opts.config_file:
+        reuse_skips = config.default_reuse_skips()
+        if opts.reports_only:
+            reuse_skips['execution'].append('run_uuid')
+
+        config.load(opts.config_file, skip=reuse_skips, init=False)
+        config.loggers.cli.info(f'Loaded previous configuration file {opts.config_file}')
 
     config.execution.log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     config.from_dict(vars(opts), init=['nipype'])
@@ -902,6 +906,7 @@ applied."""
             config.execution.fs_subjects_dir = output_dir / 'sourcedata' / 'freesurfer'
         elif output_layout == 'legacy':
             config.execution.fs_subjects_dir = output_dir / 'freesurfer'
+
     if config.execution.fmriprep_dir is None:
         if output_layout == 'bids':
             config.execution.fmriprep_dir = output_dir
@@ -945,8 +950,8 @@ applied."""
         )
         validate_input_dir(
             config.environment.exec_env,
-            opts.bids_dir,
-            opts.participant_label,
+            config.execution.bids_dir,
+            config.execution.participant_label,
             need_T1w=not config.execution.derivatives,
         )
 

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -808,8 +808,6 @@ def parse_args(args=None, namespace=None):
 
     if opts.config_file:
         reuse_skips = config.default_reuse_skips()
-        if opts.reports_only:
-            reuse_skips['execution'].append('run_uuid')
 
         config.load(opts.config_file, skip=reuse_skips, init=False)
         config.loggers.cli.info(f'Loaded previous configuration file {opts.config_file}')

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -303,7 +303,7 @@ def test_reuse_config(tmp_path):
     assert default_config['execution.output_spaces'] == 'MNI152NLin2009cAsym:res-native'
     _reset_config()
 
-    config_file = data.load.readable('tests/config.toml')
+    config_file = data.load('tests/config.toml')
     config_args = ['--config-file', str(config_file)]
     parse_args(cli_args + config_args)
     reused_config = config.get(flat=True)

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -308,12 +308,17 @@ def test_reuse_config(tmp_path):
     parse_args(cli_args + config_args)
     reused_config = config.get(flat=True)
     # Reusing the config will apply same values
-    assert reused_config['execution.output_spaces'] == 'MNI152NLin2009cAsym:res-2 MNI152NLin2009cAsym:res-native fsaverage:den-10k fsaverage:den-30k'
+    assert (
+        reused_config['execution.output_spaces']
+        == 'MNI152NLin2009cAsym:res-2 MNI152NLin2009cAsym:res-native fsaverage:den-10k fsaverage:den-30k'
+    )
     # But some will still differ
     assert reused_config['execution.log_dir'] not in config_file.read_text()
     _reset_config()
 
-    overridden_args = cli_args + config_args + ['--output-spaces', 'MNI152NLin6Asym', '--force', 'bbr']
+    overridden_args = (
+        cli_args + config_args + ['--output-spaces', 'MNI152NLin6Asym', '--force', 'bbr']
+    )
     # set new output directory
     overridden_args[1] = str(tmp_path / 'out2')
     parse_args(overridden_args)

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -300,11 +300,30 @@ def test_reuse_config(tmp_path):
 
     parse_args(cli_args)
     default_config = config.get(flat=True)
+    assert default_config['execution.output_spaces'] == 'MNI152NLin2009cAsym:res-native'
     _reset_config()
 
     config_file = data.load.readable('tests/config.toml')
-    parse_args(cli_args + ['--config-file', str(config_file)])
+    config_args = ['--config-file', str(config_file)]
+    parse_args(cli_args + config_args)
     reused_config = config.get(flat=True)
+    # Reusing the config will apply same values
+    assert reused_config['execution.output_spaces'] == 'MNI152NLin2009cAsym:res-2 MNI152NLin2009cAsym:res-native fsaverage:den-10k fsaverage:den-30k'
+    # But some will still differ
+    assert reused_config['execution.log_dir'] not in config_file.read_text()
+    _reset_config()
 
-    # TODO: override and verify
+    overridden_args = cli_args + config_args + ['--output-spaces', 'MNI152NLin6Asym', '--force', 'bbr']
+    # set new output directory
+    overridden_args[1] = str(tmp_path / 'out2')
+    parse_args(overridden_args)
+    overridden_config = config.get(flat=True)
+
+    # Passed in argument will override
+    assert overridden_config['execution.output_spaces'] == 'MNI152NLin6Asym:res-native'
+    assert 'bbr' in overridden_config['workflow.force']
+
+    # But some values will still differ
+    for v in ('execution.run_uuid', 'execution.fmriprep_dir'):
+        assert reused_config[v] != overridden_config[v]
     _reset_config()

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -28,7 +28,7 @@ from contextlib import nullcontext
 import pytest
 from packaging.version import Version
 
-from ... import config
+from ... import config, data
 from ...tests.test_config import _reset_config
 from .. import version as _version
 from ..parser import _build_parser, parse_args
@@ -286,3 +286,25 @@ def test_optional_booleans(tmp_path, supp_args, opt, expected):
     args = [str(tmp_path), out_path, 'participant'] + supp_args
     pargs = _build_parser().parse_args(args)
     assert getattr(pargs, opt) == expected
+    _reset_config()
+
+
+def test_reuse_config(tmp_path):
+    from niworkflows.utils.testing import generate_bids_skeleton
+
+    # Mirror the test config input
+    bids_dir = tmp_path / 'ds000005'
+    generate_bids_skeleton(bids_dir, {'01': {'anat': {'suffix': 'T1w'}}})
+    # Avoid requiring validator installation
+    cli_args = [str(bids_dir), str(tmp_path / 'out'), 'participant', '--skip-bids-validation']
+
+    parse_args(cli_args)
+    default_config = config.get(flat=True)
+    _reset_config()
+
+    config_file = data.load.readable('tests/config.toml')
+    parse_args(cli_args + ['--config-file', str(config_file)])
+    reused_config = config.get(flat=True)
+
+    # TODO: override and verify
+    _reset_config()

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -753,6 +753,24 @@ def from_dict(settings, init=True, ignore=None):
     loggers.init()
 
 
+# Certain config fields are not directly settable, and should not be copied when reused
+# Additionally, some toggle arguments only can be switched one way
+REUSE_SKIPS = {
+    'execution': [
+        'fmriprep_dir',
+        'notrack',
+        'templateflow_home',
+    ],
+    'workflow': [
+        'anat_only',
+    ],
+    'seeds': [],
+}
+
+def default_reuse_skips():
+    return {k: list(v) for k, v in REUSE_SKIPS.items()}
+
+
 def load(filename, skip=None, init=True):
     """Load settings from file.
 

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -757,9 +757,15 @@ def from_dict(settings, init=True, ignore=None):
 # Additionally, some toggle arguments only can be switched one way
 REUSE_SKIPS = {
     'execution': [
+        'dataset_links',
+        'layout',
+        '_layout',
         'fmriprep_dir',
         'notrack',
+        'sloppy',
         'templateflow_home',
+        'run_uuid',
+        'log_dir',
     ],
     'workflow': [
         'anat_only',

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -773,6 +773,7 @@ REUSE_SKIPS = {
     'seeds': [],
 }
 
+
 def default_reuse_skips():
     return {k: list(v) for k, v in REUSE_SKIPS.items()}
 

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -741,7 +741,9 @@ def from_dict(settings, init=True, ignore=None):
 
     # Accept global True/False or container of configs to initialize
     def initialize(x):
-        return init if init in (True, False) else x in init
+        if isinstance(init, bool):
+            return init
+        return x in init
 
     nipype.load(settings, init=initialize('nipype'), ignore=ignore)
     execution.load(settings, init=initialize('execution'), ignore=ignore)
@@ -774,10 +776,11 @@ def load(filename, skip=None, init=True):
     filename = Path(filename)
     settings = loads(filename.read_text())
     for sectionname, configs in settings.items():
-        if sectionname != 'environment':
-            section = getattr(sys.modules[__name__], sectionname)
-            ignore = skip.get(sectionname)
-            section.load(configs, ignore=ignore, init=initialize(sectionname))
+        if sectionname == 'environment':
+            continue
+        section = getattr(sys.modules[__name__], sectionname)
+        ignore = skip.get(sectionname)
+        section.load(configs, ignore=ignore, init=initialize(sectionname))
     init_spaces()
 
 


### PR DESCRIPTION
Addresses #3595

Some configuration options make reusing configuration files difficult, either due to:
- being set at run time, not when parsing arguments (`fmriprep_dir`, `log_dir`)
- not having off toggles (`anat-only`, `notrack`)

This is a smell, but rather than a big refactor this adds `config.default_reuse_skips()` which manually tracks them.