### PR TITLE
Remove cohort entity and append cohort to space

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -443,7 +443,6 @@ It is released under the [CC0]\
                     ('outputnode.std_t1w', 'inputnode.ref_file'),
                     ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
                     ('outputnode.space', 'inputnode.space'),
-                    ('outputnode.cohort', 'inputnode.cohort'),
                     ('outputnode.resolution', 'inputnode.resolution'),
                 ]),
             ])  # fmt:skip
@@ -915,7 +914,6 @@ tasks and sessions), the following preprocessing was performed.
                         ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
                         ('outputnode.space', 'inputnode.std_space'),
                         ('outputnode.resolution', 'inputnode.std_resolution'),
-                        ('outputnode.cohort', 'inputnode.std_cohort'),
                         ('outputnode.std_t1w', 'inputnode.std_t1w'),
                         ('outputnode.std_mask', 'inputnode.std_mask'),
                     ]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -136,8 +136,6 @@ def init_bold_wf(
         Value of space entity to be used in standard space output filenames
     std_resolution
         Value of resolution entity to be used in standard space output filenames
-    std_cohort
-        Value of cohort entity to be used in standard space output filenames
     anat2mni6_xfm
         Transform from anatomical space to MNI152NLin6Asym space
     mni6_mask
@@ -146,7 +144,7 @@ def init_bold_wf(
         Transform from MNI152NLin2009cAsym to anatomical space
 
     Note that ``anat2std_xfm``, ``std_space``, ``std_resolution``,
-    ``std_cohort``, ``std_t1w`` and ``std_mask`` are treated as single
+    ``std_t1w`` and ``std_mask`` are treated as single
     inputs. In order to resample to multiple target spaces, connect
     these fields to an iterable.
 
@@ -230,7 +228,6 @@ configured with cubic B-spline interpolation.
                 'std_mask',
                 'std_space',
                 'std_resolution',
-                'std_cohort',
                 # MNI152NLin6Asym warp, for CIFTI use
                 'anat2mni6_xfm',
                 'mni6_mask',
@@ -488,7 +485,6 @@ configured with cubic B-spline interpolation.
                 ('std_t1w', 'inputnode.template'),
                 ('std_space', 'inputnode.space'),
                 ('std_resolution', 'inputnode.resolution'),
-                ('std_cohort', 'inputnode.cohort'),
             ]),
             (bold_fit_wf, ds_bold_std_wf, [
                 ('outputnode.bold_mask', 'inputnode.bold_mask'),

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -784,7 +784,6 @@ def init_ds_volumes_wf(
                 'anat2std_xfm',
                 # Entities
                 'space',
-                'cohort',
                 'resolution',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
@@ -837,7 +836,6 @@ def init_ds_volumes_wf(
         (inputnode, ds_bold, [
             ('bold', 'in_file'),
             ('space', 'space'),
-            ('cohort', 'cohort'),
             ('resolution', 'resolution'),
         ]),
         (sources, ds_bold, [('out', 'Sources')]),
@@ -930,7 +928,6 @@ def init_ds_volumes_wf(
         ] + [
             (inputnode, datasink, [
                 ('space', 'space'),
-                ('cohort', 'cohort'),
                 ('resolution', 'resolution'),
             ])
             for datasink in datasinks


### PR DESCRIPTION
Closes #3365. Reproduces nipreps/nibabies#524. Depends on nipreps/smriprep#526.

## Changes proposed in this pull request

- Remove uses of `cohort` and just pass `space` along.