### PR TITLE
fix: Filter out part and echo entities before collecting functional derivatives

### DIFF
--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -55,6 +55,7 @@ def collect_derivatives(
     fieldmap_id: str | None = None,
     spec: dict | None = None,
     patterns: list[str] | None = None,
+    dismiss_entities: list[str] | None = None,
 ):
     """Gather existing derivatives and compose a cache."""
     if spec is None or patterns is None:
@@ -69,6 +70,9 @@ def collect_derivatives(
 
     derivs_cache = defaultdict(list, {})
     layout = _get_layout(derivatives_dir)
+
+    if dismiss_entities:
+        entities = {k: v for k, v in entities.items() if k not in dismiss_entities}
 
     # search for both boldrefs
     for k, q in spec['baseline'].items():

--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -55,7 +55,6 @@ def collect_derivatives(
     fieldmap_id: str | None = None,
     spec: dict | None = None,
     patterns: list[str] | None = None,
-    dismiss_entities: list[str] | None = None,
 ):
     """Gather existing derivatives and compose a cache."""
     if spec is None or patterns is None:
@@ -70,9 +69,6 @@ def collect_derivatives(
 
     derivs_cache = defaultdict(list, {})
     layout = _get_layout(derivatives_dir)
-
-    if dismiss_entities:
-        entities = {k: v for k, v in entities.items() if k not in dismiss_entities}
 
     # search for both boldrefs
     for k, q in spec['baseline'].items():

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -869,6 +869,7 @@ tasks and sessions), the following preprocessing was performed.
                         derivatives_dir=deriv_dir,
                         entities=entities,
                         fieldmap_id=fieldmap_id,
+                        dismiss_entities=dismiss_echo(['part']),
                     )
                 )
 

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -862,6 +862,8 @@ tasks and sessions), the following preprocessing was performed.
             from fmriprep.utils.bids import collect_derivatives, extract_entities
 
             entities = extract_entities(bold_series)
+            dismiss_entities = dismiss_echo(['part'])
+            entities = {k: v for k, v in entities.items() if k not in dismiss_entities}
 
             for deriv_dir in config.execution.derivatives.values():
                 functional_cache.update(
@@ -869,7 +871,6 @@ tasks and sessions), the following preprocessing was performed.
                         derivatives_dir=deriv_dir,
                         entities=entities,
                         fieldmap_id=fieldmap_id,
-                        dismiss_entities=dismiss_echo(['part']),
                     )
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.27", "hatch-vcs", "nipreps-versions"]
+requires = [
+    "hatchling>=1.27",
+    "hatch-vcs",
+    "nipreps-versions",
+    "setuptools_scm<10",  # Broken at least through 10.0.1
+]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Closes #3628.

These changes appear to be working in a local fMRIPrep run, though I think that the lack of `part` and `echo` entities in the transform files is the result of those entities not being present in the allowed filename patterns (see [nipreps.json](https://github.com/nipreps/niworkflows/blob/master/niworkflows/data/nipreps.json)), rather than explicitly being dismissed in the DerivativesDataSinks. That means that, if someone does add those entities to the filename patterns, they might appear in the filenames and break this. At least `part` might show up.

## Changes proposed in this pull request

- Filter out echo and part entities before calling `collect_derivatives`.