### PR TITLE
FIX: Improve error handling in report generation

### DIFF
--- a/fmriprep/reports/core.py
+++ b/fmriprep/reports/core.py
@@ -55,12 +55,13 @@ def run_reports(
     # Count nbr of subject for which report generation failed
     try:
         robj.generate_report()
-    except:  # noqa: E722
-        import sys
+    except Exception:  # noqa: BLE001
         import traceback
 
-        # Store the list of subjects for which report generation failed
-        traceback.print_exception(*sys.exc_info(), file=str(Path(output_dir) / 'logs' / errorname))
+        log_dir = Path(output_dir) / 'logs'
+        log_dir.mkdir(parents=True, exist_ok=True)
+        with open(log_dir / errorname, 'w') as f:
+            traceback.print_exc(file=f)
         return subject_label
 
     return None

--- a/fmriprep/reports/tests/test_report_errors.py
+++ b/fmriprep/reports/tests/test_report_errors.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from fmriprep.reports.core import run_reports
+
+
+def test_run_reports_error_handling(tmp_path):
+    with patch('fmriprep.reports.core.Report') as MockReport:
+        MockReport.return_value.generate_report.side_effect = Exception('Test Exception')
+
+        res = run_reports(
+            output_dir=str(tmp_path),
+            subject_label='01',
+            run_uuid='test_uuid',
+            errorname='report.err',
+        )
+
+        assert res == '01'
+        error_file = tmp_path / 'logs' / 'report.err'
+        assert error_file.is_file()
+
+        content = error_file.read_text()
+        assert 'Traceback' in content
+        assert 'Test Exception' in content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "hatchling>=1.27",
     "hatch-vcs",
     "nipreps-versions",
-    "setuptools_scm<10",  # Broken at least through 10.0.1
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Likely cause of #3634

Fix an issue where report generation failures were not properly caught / saved, leading to a silent workflow crash with no logger context. This adds a fix + test.