### PR TITLE
FIX: Remove redundant fmap_boldref resample in desc-fmapCoreg_bold.svg report

### DIFF
--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -313,18 +313,6 @@ def init_func_fit_reports_wf(
             mem_gb=1,
         )
 
-        fmap_boldref = pe.Node(
-            ApplyTransforms(
-                dimension=3,
-                default_value=0,
-                float=True,
-                invert_transform_flags=[True],
-                interpolation='LanczosWindowedSinc',
-            ),
-            name='fmap_boldref',
-            mem_gb=1,
-        )
-
         # SDC1
         sdcreg_report = pe.Node(
             FieldmapReportlet(
@@ -377,17 +365,12 @@ def init_func_fit_reports_wf(
                 ('coreg_boldref', 'reference_image'),
                 ('boldref2fmap_xfm', 'transforms'),
             ]),
-            (inputnode, fmap_boldref, [
-                ('fieldmap', 'input_image'),
-                ('coreg_boldref', 'reference_image'),
-                ('boldref2fmap_xfm', 'transforms'),
-            ]),
             (inputnode, sdcreg_report, [
                 ('sdc_boldref', 'reference'),
+                ('fieldmap', 'fieldmap'),
                 ('bold_mask', 'mask'),
             ]),
             (fmapref_boldref, sdcreg_report, [('output_image', 'moving')]),
-            (fmap_boldref, sdcreg_report, [('output_image', 'fieldmap')]),
             (sdcreg_report, ds_sdcreg_report, [('out_report', 'in_file')]),
             (inputnode, sdc_report, [
                 ('sdc_boldref', 'before'),

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -163,25 +163,33 @@ def init_func_fit_reports_wf(
 
     Inputs
     ------
-    std_t1w
-        T1w image resampled to standard space
-    std_mask
-        Mask of skull-stripped template
+    sdc_boldref
+        BOLD reference before SDC, in BOLD space
+    coreg_boldref
+        BOLD reference after SDC, in BOLD space
+    boldref2anat_xfm
+        Affine transform from BOLD reference to anatomical space
+    boldref2fmap_xfm
+        Affine transform from BOLD reference to fieldmap space
+    t1w_preproc
+        The T1w reference map, which is calculated as the average of bias-corrected
+        and preprocessed T1w images, defining the anatomical space.
+    t1w_mask
+        Brain (binary) mask estimated by brain extraction.
+    t1w_dseg
+        Segmentation in T1w space
+    fieldmap
+        Reconstructed fieldmap, in BOLD space
+    fmap_ref
+        Fieldmap reference image, in fieldmap space
     subject_dir
         FreeSurfer SUBJECTS_DIR
     subject_id
         FreeSurfer subject ID
-    t1w_conform_report
-        Conformation report
-    t1w_preproc
-        The T1w reference map, which is calculated as the average of bias-corrected
-        and preprocessed T1w images, defining the anatomical space.
-    t1w_dseg
-        Segmentation in T1w space
-    t1w_mask
-        Brain (binary) mask estimated by brain extraction.
-    template
-        Template space and specifications
+    summary_report
+        HTML snippet summarizing BOLD processing decisions
+    validation_report
+        HTML snippet indicating whether affine metadata were overwritten
 
     """
     from nireports.interfaces.reporting.base import (


### PR DESCRIPTION
Closes #3639.

## Changes proposed in this pull request

- Remove the `fmap_boldref` `ApplyTransforms` node from `init_func_fit_reports_wf`.
- Connect `inputnode.fieldmap` directly to `sdcreg_report.fieldmap`.

This restores the wiring that existed before #3387, which is now correct because #3467 rewired `func_fit_reports_wf.inputnode.fieldmap` to receive `boldref_fmap.out_file` — a fieldmap already reconstructed onto the BOLD reference grid.

## Why

`fmap_boldref` was added in #3387 to resample a raw RAS fieldmap into BOLD space for the `FieldmapReportlet`. After #3467 introduced `boldref_fmap` (a `ReconstructFieldmap` node) and rewired its output into the reports workflow at `fit.py:500`, the resample became redundant. Removing `fmap_boldref` restores correct rendering. Actual SDC is unaffected — `unwarp_boldref` (`fit.py:614`) and the time-series `resample` (`apply.py`) use `ReconstructFieldmap` outputs directly. See the linked issue for figures and a centroid trace.

## Impact

- **Reports:** `desc-fmapCoreg_bold.svg` now plots the fieldmap at the correct location regardless of BOLD/fmap acquisition geometry.
- **Workflow:** one node removed, two connections deleted, one connection added. `grep -rn fmap_boldref` returns zero matches after the change.
- **Other outputs:** none affected. `fmap_boldref` was reports-only.

## Testing

- Built `init_func_fit_reports_wf` under `sdc_correction=True/False` × `freesurfer=True/False` and walked the workflow graph: `fmap_boldref` is gone, and `sdcreg_report.fieldmap` is connected directly from `inputnode.fieldmap` post-fix; the other three required inputs (`reference`, `moving`, `mask`) remain wired as before.
- Reproduced the bug on a real subject with fmriprep `25.2.5` (figures in the linked issue) and verified the fix produces correctly-located overlays by invoking `FieldmapReportlet` with the proposed wiring.
- `ruff check`, `ruff format --check`, and `codespell` pass on the modified file.

## Documentation that should be reviewed

None.
