### PR TITLE
doc: Add note on StartTime metadata

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -379,6 +379,10 @@ to perform more advanced denoising or alternative combination strategies.
    In contrast to volume onsets, event onsets need to be shifted *backward* by half a TR,
    for example, from [5, 10, 15] to [4, 9, 14].
 
+   In versions 20.2.4 and later, *fMRIPrep* adds the `StartTime` metadata field to
+   `*_bold.json` sidecar files, which indicates the time shift applied to the volume onsets.
+   When available, this should be considered authoritative and applied by modeling tools.
+
    Further information on this issue is found at
    `this blog post (with thanks to Russell Poldrack and Jeanette Mumford)
    <https://reproducibility.stanford.edu/slice-timing-correction-in-fmriprep-and-linear-modeling/>`__.


### PR DESCRIPTION
This PR adds a note on StartTime metadata. We previously warned that STC impacts modeling decisions, but did not indicate that the necessary metadata to automatically adjust onsets was included in recent versions in the documentation.

## Documentation that should be reviewed

* [Functional derivatives](https://fmriprep--3670.org.readthedocs.build/en/3670/outputs.html#functional-derivatives)

cc @jmumford