### PR TITLE
chore: Fix py310-min tests on CI [LTS]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - master
+      - main
       - maint/*
-      - next
   pull_request:
     branches:
       - master
+      - main
       - maint/*
-      - next
 
 defaults:
   run:
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        dependencies: ['latest', 'pre']
+        dependencies: ['latest']
         include:
           - os: ubuntu-latest
             python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,10 @@ jobs:
           uv tool install --with=tox-uv --with=tox-gh-actions tox
       - name: Show tox config
         run: tox c
-      - name: Run tox
-        run: tox -v --exit-and-dump-after 1200
+      - name: Setup test suite
+        run: tox run -vv --notest
+      - name: Run test suite
+        run: tox -v --skip-pkg-install --exit-and-dump-after 1200
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -94,5 +96,7 @@ jobs:
         run: uv tool install tox --with=tox-uv
       - name: Show tox config
         run: tox c -e ${{ matrix.check }}
+      - name: Setup check environment
+        run: tox -vv --notest -e ${{ matrix.check }}
       - name: Run check
-        run: tox -e ${{ matrix.check }}
+        run: tox --skip-pkg-install -e ${{ matrix.check }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,25 +78,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: ${{ always() }}
-
-  checks:
-    runs-on: "ubuntu-latest"
-    continue-on-error: true
-    strategy:
-      matrix:
-        check: ["style", "spellcheck"]
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6
-      - name: Install tox
-        run: uv tool install tox --with=tox-uv
-      - name: Show tox config
-        run: tox c -e ${{ matrix.check }}
-      - name: Setup check environment
-        run: tox -vv --notest -e ${{ matrix.check }}
-      - name: Run check
-        run: tox --skip-pkg-install -e ${{ matrix.check }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,11 @@ telemetry = [
     "sentry-sdk >= 1.3",
 ]
 test = [
-    "coverage[toml] >= 5.2.1",
-    "pytest >= 8.1",
-    "pytest-cov >= 2.11",
-    "pytest-env",
-    "pytest-xdist >= 2.5",
+    "coverage[toml] >= 7.6.2",
+    "pytest >= 8.3.3",
+    "pytest-cov >= 6.0.0",
+    "pytest-env >= 1.1.4",
+    "pytest-xdist >= 3.7.0",
 ]
 maint = [
     "fuzzywuzzy",

--- a/tox.ini
+++ b/tox.ini
@@ -53,35 +53,6 @@ commands_pre =
 commands =
   pytest --cov-report term-missing --durations=20 --durations-min=1.0 {posargs:-n auto}
 
-[testenv:style]
-description = Check our style guide
-labels = check
-deps =
-  ruff
-skip_install = true
-commands =
-  ruff check --diff
-  ruff format --diff
-
-[testenv:style-fix]
-description = Auto-apply style guide to the extent possible
-labels = pre-release
-deps =
-  ruff
-skip_install = true
-commands =
-  ruff check --fix
-  ruff format
-
-[testenv:spellcheck]
-description = Check spelling
-labels = check
-deps =
-  codespell[toml]
-skip_install = true
-commands =
-  codespell . {posargs}
-
 [testenv:build{,-strict}]
 labels =
   check


### PR DESCRIPTION
This fixes CI failures on the LTS branch related to py310-min. It also removes pre-release tests altogether. Adding a cronjob prerelease test will be a separate PR against master.

Minor additional change of separating out the tox environment build and run steps, which can help quickly distinguish install from test failures.